### PR TITLE
Preview is now called 'DRAFT' in header

### DIFF
--- a/app/com/gu/viewer/views/viewer.scala.html
+++ b/app/com/gu/viewer/views/viewer.scala.html
@@ -17,7 +17,11 @@
             <div class="top-toolbar__view-toolbar">
                 <ul class="tool-bar">
                     <li class="top-toolbar__container">
-                        <div class="top-toolbar__status--@previewEnv">@previewEnv</div>
+                        @if(previewEnv == "preview") {
+                            <div class="top-toolbar__status--@previewEnv">DRAFT</div>
+                        } else {
+                            <div class="top-toolbar__status--@previewEnv">@previewEnv</div>
+                        }
                     <!--</li>-->
                     <li class="top-toolbar__container">
                         <div class="top-toolbar__label">Mobile web</div>


### PR DESCRIPTION
Only a user facing change, preview is now called DRAFT in the header to match composer. Added an exception to the current use-of-previewEnv rendering to reflect that.
