### PR TITLE
Redirect server relative links from Proxied responses 

### DIFF
--- a/app/com/gu/viewer/controllers/Proxy.scala
+++ b/app/com/gu/viewer/controllers/Proxy.scala
@@ -191,7 +191,7 @@ class Proxy @Inject() (ws: WSClient) extends Controller {
 
     request.headers.get("Referer") match {
       case Some(fromProxy(`host`, service)) => {
-        val queryString = if (request.rawQueryString.isEmpty) "" else request.rawQueryString
+        val queryString = if (request.rawQueryString.isEmpty) "" else s"?${request.rawQueryString}"
         Redirect(routes.Proxy.proxy(service, s"$path$queryString"))
       }
 

--- a/app/com/gu/viewer/controllers/Proxy.scala
+++ b/app/com/gu/viewer/controllers/Proxy.scala
@@ -190,10 +190,8 @@ class Proxy @Inject() (ws: WSClient) extends Controller {
     val host = request.host
 
     request.headers.get("Referer") match {
-      case Some(fromProxy(`host`, service)) => {
-        val queryString = if (request.rawQueryString.isEmpty) "" else s"?${request.rawQueryString}"
-        Redirect(routes.Proxy.proxy(service, s"$path$queryString"))
-      }
+      case Some(fromProxy(`host`, service)) =>
+        Redirect(routes.Proxy.proxy(service, request.uri.tail))
 
       case _ => NotFound(s"Resource not found: $path")
     }

--- a/app/com/gu/viewer/controllers/Proxy.scala
+++ b/app/com/gu/viewer/controllers/Proxy.scala
@@ -179,4 +179,22 @@ class Proxy @Inject() (ws: WSClient) extends Controller {
     }
   }
 
+
+  /**
+   * Redirect requests to routes that don't exist which originate (Referer header)
+   * from a proxied request. Catches server relative requests in a proxied response.
+   */
+  def redirectRelative(path: String) = Action { request =>
+
+    val fromProxy = """^\w+:\/\/viewer.local.dev-gutools.co.uk\/proxy\/([^/]+).*$""".r
+
+    request.headers.get("Referer") match {
+      case Some(fromProxy(service)) => {
+        val queryString = if (request.rawQueryString.isEmpty) "" else request.rawQueryString
+        Redirect(routes.Proxy.proxy(service, s"$path$queryString"))
+      }
+
+      case _ => NotFound(s"Resource not found: $path")
+    }
+  }
 }

--- a/app/com/gu/viewer/controllers/Proxy.scala
+++ b/app/com/gu/viewer/controllers/Proxy.scala
@@ -186,10 +186,11 @@ class Proxy @Inject() (ws: WSClient) extends Controller {
    */
   def redirectRelative(path: String) = Action { request =>
 
-    val fromProxy = """^\w+:\/\/viewer.local.dev-gutools.co.uk\/proxy\/([^/]+).*$""".r
+    val fromProxy = """^\w+:\/\/([^/]+)\/proxy\/([^/]+).*$""".r
+    val host = request.host
 
     request.headers.get("Referer") match {
-      case Some(fromProxy(service)) => {
+      case Some(fromProxy(`host`, service)) => {
         val queryString = if (request.rawQueryString.isEmpty) "" else request.rawQueryString
         Redirect(routes.Proxy.proxy(service, s"$path$queryString"))
       }

--- a/conf/routes
+++ b/conf/routes
@@ -20,3 +20,4 @@ GET        /proxy/live/*path              com.gu.viewer.controllers.Proxy.proxy(
 # Map static resources from the /public folder to the /assets URL path
 GET        /assets/*file                  controllers.Assets.versioned(path="/public", file: Asset)
 
+GET        /*path                         com.gu.viewer.controllers.Proxy.redirectRelative(path)


### PR DESCRIPTION
When rendering a proxied response, some links and resources are loaded into the page as server relative.

This PR catches those requests, but looking at the `Referer` header and redirecting the request if it originates from a proxied response.

This avoids using a `<base>` tag, which may have issues resolving ajax requests.
