### PR TITLE
Integrate with the proxy for viewer

### DIFF
--- a/app/com/gu/viewer/controllers/Application.scala
+++ b/app/com/gu/viewer/controllers/Application.scala
@@ -19,16 +19,17 @@ class Application extends Controller {
     viewer("live", path, "live")
   }
 
-  def viewer(target: String, path: String, previewEnv: String) = Action { request =>
+  def viewer(target: String, path: String, previewEnv: String) = Action { implicit request =>
     val protocol = if (request.secure) "https" else "http"
     val viewerHost = target match {
       case "preview" => Configuration.previewHost
       case _ => Configuration.liveHost
     }
-    val viewerUrl = s"$protocol://$viewerHost/$path"
+    val actualUrl = s"$protocol://$viewerHost/$path"
+    val viewerUrl = routes.Proxy.proxy(target, path).absoluteURL()
     val composerUrl = Configuration.composerReturn + "/" + path
 
-    Ok(html.viewer(viewerUrl, previewEnv, composerUrl))
+    Ok(html.viewer(viewerUrl, actualUrl, previewEnv, composerUrl))
   }
 
 }

--- a/app/com/gu/viewer/controllers/Proxy.scala
+++ b/app/com/gu/viewer/controllers/Proxy.scala
@@ -94,8 +94,8 @@ class Proxy @Inject() (ws: WSClient) extends Controller with Loggable {
       proxyRequest.get().flatMap { response =>
         (response.status, response.header("Location")) match {
           case (303, Some(`previewLoginUrl`)) => doPreviewAuth()
-          case _ => Future.successful {
-            Ok(response.body)
+          case (status, _) => Future.successful {
+            Status(status)(response.body)
               .withSession(request.session)
 
               .as(response.header("Content-Type").getOrElse("text/plain"))

--- a/app/com/gu/viewer/controllers/Proxy.scala
+++ b/app/com/gu/viewer/controllers/Proxy.scala
@@ -1,6 +1,7 @@
 package com.gu.viewer.controllers
 
 import com.gu.viewer.config.Configuration
+import com.gu.viewer.views.html
 import java.net.URLEncoder
 import javax.inject.Inject
 import play.api.libs.concurrent.Execution.Implicits._
@@ -59,8 +60,8 @@ class Proxy @Inject() (ws: WSClient) extends Controller {
 
               previewSessionOpt match {
                 case Some(session) => {
-                  val returnUrl = SESSION_KEY_RETURN_URL -> request.uri
-                  Redirect(loc)
+                  val returnUrl = SESSION_KEY_RETURN_URL -> request.headers.get("Referer").getOrElse(request.uri)
+                  Ok(html.loginRedirect(loc))
                     .withSession(request.session - SESSION_KEY_PREVIEW_SESSION - SESSION_KEY_PREVIEW_AUTH + session + returnUrl)
                 }
 

--- a/app/com/gu/viewer/controllers/Proxy.scala
+++ b/app/com/gu/viewer/controllers/Proxy.scala
@@ -94,6 +94,11 @@ class Proxy @Inject() (ws: WSClient) extends Controller with Loggable {
       proxyRequest.get().flatMap { response =>
         (response.status, response.header("Location")) match {
           case (303, Some(`previewLoginUrl`)) => doPreviewAuth()
+          case (303, Some("/login")) => doPreviewAuth()
+          case (status, Some(otherLocation)) => {
+            log.warn(s"Proxied response for $url is $status redirect to: $otherLocation")
+            Future.successful(Status(status).withHeaders("Location" -> otherLocation))
+          }
           case (status, _) => Future.successful {
             Status(status)(response.body)
               .withSession(request.session)

--- a/app/com/gu/viewer/views/loginRedirect.scala.html
+++ b/app/com/gu/viewer/views/loginRedirect.scala.html
@@ -1,0 +1,10 @@
+@(redirectUrl: String)
+<!DOCTYPE html>
+<html>
+    <head>
+        <script>window.top.location.href = "@Html(redirectUrl)";</script>
+    </head>
+    <body>
+        <noscript><a href="@redirectUrl" target="_top">Login</a></noscript>
+    </body>
+</html>

--- a/app/com/gu/viewer/views/viewer.scala.html
+++ b/app/com/gu/viewer/views/viewer.scala.html
@@ -1,4 +1,4 @@
-@(viewerUrl: String, previewEnv: String, composerUrl: String)
+@(viewerUrl: String, actualUrl: String, previewEnv: String, composerUrl: String)
 
 @main("Viewer") {
     <header class="fixed-header">
@@ -35,7 +35,7 @@
                         <li data-switchmode="desktop" class="top-toolbar__button"><i class="top-toolbar__icon--desktop"></i>Desktop<!--</li>-->
                     } else {
                         <li data-switchmode="desktop" class="top-toolbar__button is-always-visible"><i class="top-toolbar__icon--desktop"></i>Desktop<!--</li>-->
-                        <li class="top-toolbar__container"><a href="@viewerUrl" class="top-toolbar__button"><i class="top-toolbar__icon--guardian"></i>View on theguardian.com</a><!--</li>-->
+                        <li class="top-toolbar__container"><a href="@actualUrl" class="top-toolbar__button"><i class="top-toolbar__icon--guardian"></i>View on theguardian.com</a><!--</li>-->
                     }
                 </ul>
             </div>


### PR DESCRIPTION
- Use proxy for pages in viewer iframe
- Break out of iframe when auth expires with preview, and handle redirecting back to iframed page.
