### PR TITLE
Redirect to proxy on mobile devices.

### DIFF
--- a/app/com/gu/viewer/views/viewer.scala.html
+++ b/app/com/gu/viewer/views/viewer.scala.html
@@ -59,6 +59,7 @@
     </div>
 
     <script>
-        window._previewEnv = "@previewEnv"
+        window._previewEnv = "@previewEnv";
+        window._actualUrl = "@actualUrl";
     </script>
 }

--- a/public/javascript/components/viewer.js
+++ b/public/javascript/components/viewer.js
@@ -111,7 +111,11 @@ function onViewerLoad() {
 
 function detectMobileAndRedirect() {
     if (window.screen && window.screen.width <= 768) {
-        window.location.href = viewerEl.src;
+        if (window._actualUrl) {
+            window.location.href = window._actualUrl;
+        } else {
+            window.location.href = viewerEl.src;
+        }
     }
 }
 

--- a/public/javascript/components/viewer.js
+++ b/public/javascript/components/viewer.js
@@ -109,7 +109,15 @@ function onViewerLoad() {
     }
 }
 
+function detectMobileAndRedirect() {
+    if (window.screen && window.screen.width <= 768) {
+        window.location.href = viewerEl.src;
+    }
+}
+
 function init() {
+
+    detectMobileAndRedirect();
     viewerEl.addEventListener('load', onViewerLoad);
 }
 

--- a/public/javascript/controllers/application.js
+++ b/public/javascript/controllers/application.js
@@ -8,6 +8,7 @@ var desktopEnabled, activeMode;
 var defaultMode = 'mobile-portrait';
 
 function init(options) {
+    
     activeMode = defaultMode;
 
     bindClicks();


### PR DESCRIPTION
This adds mobile detection (where screen width is <= 768) and redirects directly to the proxy.

I chose 768px as the issue is iOS specific, so need to also redirect iPad, and I'm redirecting to the proxy so both systems are powered from the same place. 
