### PR TITLE
Remove mixpanel identify - possible cookie issue

### DIFF
--- a/public/javascript/controllers/analytics.js
+++ b/public/javascript/controllers/analytics.js
@@ -2,15 +2,15 @@ var isEnabled = false;
 
 var pageOpenTime = Date.now();
 
-function guid() {
-  function s4() {
-    return Math.floor((1 + Math.random()) * 0x10000)
-      .toString(16)
-      .substring(1);
-  }
-  return s4() + s4() + '-' + s4() + '-' + s4() + '-' +
-    s4() + '-' + s4() + s4() + s4();
-}
+// function guid() {
+//   function s4() {
+//     return Math.floor((1 + Math.random()) * 0x10000)
+//       .toString(16)
+//       .substring(1);
+//   }
+//   return s4() + s4() + '-' + s4() + '-' + s4() + '-' +
+//     s4() + '-' + s4() + s4() + s4();
+// }
 
 
 function init() {
@@ -20,11 +20,8 @@ function init() {
 
     isEnabled = true;
 
-    var unique = guid()
-    mixpanel.identify(unique);
-
-    //TODO Generate session parameter?
-    //TODO Get user info?
+    //var unique = guid()
+    //mixpanel.identify(unique);
 }
 
 function recordPageOpen() {


### PR DESCRIPTION
This removes the unique id generated on load which should replace the Mixpanel cookie with a new cookie, but instead seems to be in some cases adding an additional cookie, but not removing the old one.
