### PR TITLE
Change method of refreshing ad block status 

### DIFF
--- a/public/javascript/components/viewer.js
+++ b/public/javascript/components/viewer.js
@@ -48,11 +48,9 @@ function updateUrl(url) {
         newiFrameUrl += '#';
     }
 
-    //This is needed to force a refresh when only the hash value has changed.
-    viewerEl.src = 'about:blank';
-    setTimeout(function() {
-        viewerEl.src = newiFrameUrl;
-    }, 1);
+    viewerEl.src = newiFrameUrl;
+    viewerEl.contentWindow.location.reload();
+
 }
 
 function printViewer() {


### PR DESCRIPTION
To improve firefox compatibility, change the about:blank before changing to url method of enabling ad block to a refresh after url change. This works better with firefox which in come cases would ignore the url navigation after about:blank was loaded.
