### PR TITLE
Revert of Change method of refreshing ad block status

### DIFF
--- a/app/com/gu/viewer/views/viewer.scala.html
+++ b/app/com/gu/viewer/views/viewer.scala.html
@@ -56,7 +56,7 @@
 
     <div class="content">
         <div class="viewers">
-            <iframe id="viewer" class="viewer" src="@viewerUrl"></iframe>
+            <iframe id="viewer" class="viewer is-mobile-portrait" src="@viewerUrl"></iframe>
         </div>
     </div>
 

--- a/public/javascript/components/viewer.js
+++ b/public/javascript/components/viewer.js
@@ -52,8 +52,15 @@ function updateUrl(url) {
         newiFrameUrl += '#';
     }
 
-    viewerEl.contentWindow.location.replace(newiFrameUrl);
+    viewerEl.src(newiFrameUrl);
     viewerEl.contentWindow.location.reload(true);
+
+    viewerEl.src = 'about:blank';
+
+    setTimeout(function() {
+        viewerEl.src = newiFrameUrl;
+    }, 100);
+
 }
 
 function printViewer() {

--- a/public/javascript/components/viewer.js
+++ b/public/javascript/components/viewer.js
@@ -11,7 +11,6 @@ var adsBlocked;
 
 function updateViewer(viewportName, viewportConfig) {
 
-    //No Change, ignore;
     if (viewportName === currentViewPortName) {
         return;
     }
@@ -55,7 +54,6 @@ function updateUrl(url) {
 
     viewerEl.src = newiFrameUrl;
     viewerEl.contentWindow.location.reload();
-
 }
 
 function printViewer() {
@@ -105,9 +103,6 @@ function restyleViewer(isAnimated, preventRefresh) {
         viewerEl.classList.add('is-animated');
         viewerEl.addEventListener('transitionend', transitionEndHandler);
     }
-
-    viewerEl.style.width = currentViewPortConfig.width;
-    viewerEl.style.height = currentViewPortConfig.height;
 
     if (!isAnimated && !preventRefresh) {
         reloadiFrame();

--- a/public/javascript/components/viewer.js
+++ b/public/javascript/components/viewer.js
@@ -52,8 +52,8 @@ function updateUrl(url) {
         newiFrameUrl += '#';
     }
 
-    viewerEl.contentWindow.location = newiFrameUrl;
-    viewerEl.contentWindow.location.reload();
+    viewerEl.contentWindow.location.replace(newiFrameUrl);
+    viewerEl.contentWindow.location.reload(true);
 }
 
 function printViewer() {

--- a/public/javascript/components/viewer.js
+++ b/public/javascript/components/viewer.js
@@ -5,11 +5,16 @@ var currentViewerUrl = viewerEl.src;
 var errorController = require('../controllers/error.js');
 
 var currentViewPortConfig;
-var currentViewPortName;
+var currentViewPortName = 'mobile-portrait';
 
 var adsBlocked;
 
 function updateViewer(viewportName, viewportConfig) {
+
+    //No Change, ignore;
+    if (viewportName === currentViewPortName) {
+        return;
+    }
 
     var isAnimated = false;
     var preventRefresh = false;

--- a/public/javascript/components/viewer.js
+++ b/public/javascript/components/viewer.js
@@ -52,9 +52,6 @@ function updateUrl(url) {
         newiFrameUrl += '#';
     }
 
-    viewerEl.src(newiFrameUrl);
-    viewerEl.contentWindow.location.reload(true);
-
     viewerEl.src = 'about:blank';
 
     setTimeout(function() {

--- a/public/javascript/components/viewer.js
+++ b/public/javascript/components/viewer.js
@@ -52,7 +52,7 @@ function updateUrl(url) {
         newiFrameUrl += '#';
     }
 
-    viewerEl.src = newiFrameUrl;
+    viewerEl.contentWindow.location = newiFrameUrl;
     viewerEl.contentWindow.location.reload();
 }
 

--- a/public/javascript/controllers/application.js
+++ b/public/javascript/controllers/application.js
@@ -17,8 +17,6 @@ function init(options) {
     updateViews();
     checkDesktopEnabled();
     checkAdBlockStatus();
-
-
 }
 
 function checkDesktopEnabled() {

--- a/public/javascript/modes.js
+++ b/public/javascript/modes.js
@@ -1,21 +1,13 @@
 module.exports = {
     'mobile-portrait': {
-        isMobile: true,
-        width:    '330px',
-        height:   '568px'
+        isMobile: true
     },
     'mobile-landscape': {
-        isMobile: true,
-        width:    '568px',
-        height:   '320px'
+        isMobile: true
     },
     'desktop': {
-        width:  '',
-        height: ''
     },
     'reader': {
-        width:    '',
-        height:   '',
-        isReader: true,
+        isReader: true
     }
 };

--- a/public/styles/components/_viewer.scss
+++ b/public/styles/components/_viewer.scss
@@ -13,10 +13,14 @@
 
     &.is-mobile-portrait {
         border-width: 30px 20px 60px 20px;
+        width: 330px;
+        height: 568px;
     }
 
     &.is-mobile-landscape {
         border-width: 20px 60px 30px 30px;
+        width: 568px;
+        height: 320px;
     }
 
     &.is-desktop,


### PR DESCRIPTION
Reverted #32 as broke on initial load if adBlock enabled on CODE. 

Increased timeout to fix firefox issue of not navigating to url after about:blank.

Setup view to reflect initial state of mobile-portrait, so no reload required on DOM ready.
