### PR TITLE
Enable Ad Block by default

### DIFF
--- a/app/com/gu/viewer/views/viewer.scala.html
+++ b/app/com/gu/viewer/views/viewer.scala.html
@@ -56,7 +56,7 @@
 
     <div class="content">
         <div class="viewers">
-            <iframe id="viewer" class="viewer" src="@viewerUrl"></iframe>
+            <iframe id="viewer" class="viewer" src="@viewerUrl#noads"></iframe>
         </div>
     </div>
 

--- a/public/javascript/components/viewer.js
+++ b/public/javascript/components/viewer.js
@@ -7,7 +7,7 @@ var errorController = require('../controllers/error.js');
 var currentViewPortConfig;
 var currentViewPortName;
 
-var adsBlocked;
+var adBlockDisabled;
 
 function updateViewer(viewportName, viewportConfig) {
 
@@ -42,10 +42,10 @@ function updateUrl(url) {
 
     var newiFrameUrl = url;
 
-    if (adsBlocked) {
-        newiFrameUrl += '#noads';
-    } else {
+    if (adBlockDisabled) {
         newiFrameUrl += '#';
+    } else {
+        newiFrameUrl += '#noads';
     }
 
     //This is needed to force a refresh when only the hash value has changed.
@@ -145,13 +145,13 @@ function detectMobileAndRedirect() {
 }
 
 function enableAdBlock() {
-    adsBlocked = true;
+    adBlockDisabled = false;
 
     reloadiFrame();
 }
 
 function disableAdBlock() {
-    adsBlocked = false;
+    adBlockDisabled = true;
 
     reloadiFrame();
 }

--- a/public/javascript/controllers/application.js
+++ b/public/javascript/controllers/application.js
@@ -129,16 +129,16 @@ function toggleDesktop() {
 
 function toggleAds() {
     if (adsBlocked) {
-        localStorageUtil.saveAdBlockEnabledUntil(false);
+        var tenHoursFromNow = Date.now() + (1000 * 60 * 60 * 10);
+        localStorageUtil.saveAdBlockDisabledUntil(tenHoursFromNow);
+
+
         adsBlocked = false;
         viewer.disableAdBlock();
 
     } else {
         viewer.enableAdBlock();
-
-        var tenHoursFromNow = Date.now() + (1000 * 60 * 60 * 10);
-        localStorageUtil.saveAdBlockEnabledUntil(tenHoursFromNow);
-
+        localStorageUtil.saveAdBlockDisabledUntil(false);
         adsBlocked = true;
         analyticsCtrl.recordAdsDisabled();
     }

--- a/public/javascript/controllers/application.js
+++ b/public/javascript/controllers/application.js
@@ -38,12 +38,12 @@ function checkDesktopEnabled() {
 }
 
 function checkAdBlockStatus() {
-    localStorageUtil.getAdBlockStatus().then(function(adsBlockedUntil) {
-        if (adsBlockedUntil && Date.now() < adsBlockedUntil) {
-            adsBlocked = true;
-            viewer.enableAdBlock();
-        } else {
+    localStorageUtil.getAdBlockStatus().then(function(adsBlockedDisabledUntil) {
+        if (adsBlockedDisabledUntil && Date.now() < adsBlockedDisabledUntil) {
             adsBlocked = false;
+            viewer.disableAdBlock();
+        } else {
+            adsBlocked = true;
         }
 
         updateClasses();

--- a/public/javascript/utils/localStorage.js
+++ b/public/javascript/utils/localStorage.js
@@ -3,7 +3,7 @@ var localforage = require('localforage');
 var ENABLED_PAGES_MAX = 100;
 var ENABLED_PAGES_KEY = 'desktopEnabled';
 
-var ADBLOCK_ENABLED_UNTILL_KEY = 'adblockEnabled';
+var ADBLOCK_DISABLED_UNTILL_KEY = 'adblockDisabled';
 
 function getEnabledHrefs() {
     return localforage.getItem(ENABLED_PAGES_KEY);
@@ -14,11 +14,11 @@ function saveEnabledHrefs(hrefs) {
 }
 
 function saveAdBlockStatus(status) {
-    return localforage.setItem(ADBLOCK_ENABLED_UNTILL_KEY, status);
+    return localforage.setItem(ADBLOCK_DISABLED_UNTILL_KEY, status);
 }
 
 function getAdBlockStatus() {
-    return localforage.getItem(ADBLOCK_ENABLED_UNTILL_KEY);
+    return localforage.getItem(ADBLOCK_DISABLED_UNTILL_KEY);
 }
 
 function addEnabledHref(href) {

--- a/public/javascript/utils/localStorage.js
+++ b/public/javascript/utils/localStorage.js
@@ -49,7 +49,7 @@ function addEnabledHref(href) {
 
 function removeEnabledHref(href) {
 
-    getEnabledHrefs().then(function(hrefs){
+    getEnabledHrefs().then(function(hrefs) {
 
         if (!Array.isArray(hrefs) || hrefs.indexOf(href) === -1) {
             //Didn't find the href... just return;
@@ -62,9 +62,9 @@ function removeEnabledHref(href) {
 }
 
 module.exports = {
-    addEnabledHref:          addEnabledHref,
-    removeEnabledHref:       removeEnabledHref,
-    getEnabledHrefs:         getEnabledHrefs,
-    saveAdBlockEnabledUntil: saveAdBlockStatus,
-    getAdBlockStatus:        getAdBlockStatus
+    addEnabledHref:           addEnabledHref,
+    removeEnabledHref:        removeEnabledHref,
+    getEnabledHrefs:          getEnabledHrefs,
+    saveAdBlockDisabledUntil: saveAdBlockStatus,
+    getAdBlockStatus:         getAdBlockStatus
 };


### PR DESCRIPTION
fixes #30 

This PR enables ad block by default, but allows it to be deactivated for up to a day before being reenabled.
