### PR TITLE
Locking JSPM version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "bundlejs": "jspm bundle javascript/main --inject --minify",
     "sass": "node-sass ./public/styles/index.scss -o ./public/styles/ --include-path ",
     "watch": "node-sass ./public/styles/index.scss -o ./public/styles/ --watch ./public/styles/",
-    "postinstall": "jspm install -y && npm run sass"
+    "postinstall": "jspm install -y --lock && npm run sass"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/guardian/editorial-viewer#readme",
   "dependencies": {
     "eslint": "^1.1.0",
-    "jspm": "^0.16.1",
+    "jspm": "0.16.11",
     "node-sass": "^3.2.0"
   },
   "jspm": {

--- a/public/config.js
+++ b/public/config.js
@@ -12,35 +12,6 @@ System.config({
     "github:*": "jspm_packages/github/*",
     "npm:*": "jspm_packages/npm/*"
   },
-  bundles: {
-    "build.js": [
-      "javascript/main.js",
-      "javascript/controllers/analytics.js",
-      "javascript/controllers/history.js",
-      "javascript/controllers/application.js",
-      "javascript/controllers/keyboard.js",
-      "javascript/controllers/error.js",
-      "javascript/utils/button.js",
-      "javascript/utils/localStorage.js",
-      "javascript/components/viewer.js",
-      "javascript/modes.js",
-      "npm:localforage@1.2.10",
-      "npm:localforage@1.2.10/src/localforage",
-      "npm:localforage@1.2.10/src/drivers/indexeddb",
-      "npm:promise@5.0.0",
-      "npm:localforage@1.2.10/src/drivers/localstorage",
-      "npm:localforage@1.2.10/src/drivers/websql",
-      "npm:promise@5.0.0/index",
-      "npm:localforage@1.2.10/src/utils/serializer",
-      "npm:asap@1.0.0",
-      "npm:promise@5.0.0/core",
-      "npm:asap@1.0.0/asap",
-      "github:jspm/nodelibs-process@0.1.2",
-      "github:jspm/nodelibs-process@0.1.2/index",
-      "npm:process@0.11.2",
-      "npm:process@0.11.2/browser"
-    ]
-  },
 
   map: {
     "babel": "npm:babel-core@5.8.25",

--- a/public/config.js
+++ b/public/config.js
@@ -12,6 +12,35 @@ System.config({
     "github:*": "jspm_packages/github/*",
     "npm:*": "jspm_packages/npm/*"
   },
+  bundles: {
+    "build.js": [
+      "javascript/main.js",
+      "javascript/controllers/analytics.js",
+      "javascript/controllers/history.js",
+      "javascript/controllers/application.js",
+      "javascript/controllers/keyboard.js",
+      "javascript/controllers/error.js",
+      "javascript/utils/button.js",
+      "javascript/utils/localStorage.js",
+      "javascript/components/viewer.js",
+      "javascript/modes.js",
+      "npm:localforage@1.2.10",
+      "npm:localforage@1.2.10/src/localforage",
+      "npm:localforage@1.2.10/src/drivers/indexeddb",
+      "npm:promise@5.0.0",
+      "npm:localforage@1.2.10/src/drivers/localstorage",
+      "npm:localforage@1.2.10/src/drivers/websql",
+      "npm:promise@5.0.0/index",
+      "npm:localforage@1.2.10/src/utils/serializer",
+      "npm:asap@1.0.0",
+      "npm:promise@5.0.0/core",
+      "npm:asap@1.0.0/asap",
+      "github:jspm/nodelibs-process@0.1.2",
+      "github:jspm/nodelibs-process@0.1.2/index",
+      "npm:process@0.11.2",
+      "npm:process@0.11.2/browser"
+    ]
+  },
 
   map: {
     "babel": "npm:babel-core@5.8.25",

--- a/public/config.js
+++ b/public/config.js
@@ -14,37 +14,56 @@ System.config({
   },
 
   map: {
-    "babel": "npm:babel-core@5.8.23",
-    "babel-runtime": "npm:babel-runtime@5.8.20",
-    "core-js": "npm:core-js@1.1.4",
+    "babel": "npm:babel-core@5.8.25",
+    "babel-runtime": "npm:babel-runtime@5.8.25",
+    "core-js": "npm:core-js@1.2.1",
     "localforage": "npm:localforage@1.2.10",
+    "github:jspm/nodelibs-assert@0.1.0": {
+      "assert": "npm:assert@1.3.0"
+    },
     "github:jspm/nodelibs-path@0.1.0": {
       "path-browserify": "npm:path-browserify@0.0.0"
     },
-    "github:jspm/nodelibs-process@0.1.1": {
-      "process": "npm:process@0.10.1"
+    "github:jspm/nodelibs-process@0.1.2": {
+      "process": "npm:process@0.11.2"
+    },
+    "github:jspm/nodelibs-util@0.1.0": {
+      "util": "npm:util@0.10.3"
     },
     "npm:asap@1.0.0": {
-      "process": "github:jspm/nodelibs-process@0.1.1"
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
-    "npm:babel-runtime@5.8.20": {
-      "process": "github:jspm/nodelibs-process@0.1.1"
+    "npm:assert@1.3.0": {
+      "util": "npm:util@0.10.3"
     },
-    "npm:core-js@1.1.4": {
+    "npm:babel-runtime@5.8.25": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:core-js@1.2.1": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "process": "github:jspm/nodelibs-process@0.1.1",
+      "process": "github:jspm/nodelibs-process@0.1.2",
       "systemjs-json": "github:systemjs/plugin-json@0.1.0"
+    },
+    "npm:inherits@2.0.1": {
+      "util": "github:jspm/nodelibs-util@0.1.0"
     },
     "npm:localforage@1.2.10": {
       "path": "github:jspm/nodelibs-path@0.1.0",
-      "process": "github:jspm/nodelibs-process@0.1.1",
+      "process": "github:jspm/nodelibs-process@0.1.2",
       "promise": "npm:promise@5.0.0"
     },
     "npm:path-browserify@0.0.0": {
-      "process": "github:jspm/nodelibs-process@0.1.1"
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:process@0.11.2": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0"
     },
     "npm:promise@5.0.0": {
       "asap": "npm:asap@1.0.0"
+    },
+    "npm:util@0.10.3": {
+      "inherits": "npm:inherits@2.0.1",
+      "process": "github:jspm/nodelibs-process@0.1.2"
     }
   }
 });


### PR DESCRIPTION
This fixes an issue caused by the current jspm patch update by locking jspm to the previous patch version.

https://github.com/systemjs/systemjs/issues/837

`jspm install` is now called with `--lock` which will maintain the jspm dependency versions stored in the config.js.
