### PR TITLE
Support for POST in viewer proxy

### DIFF
--- a/app/com/gu/viewer/proxy/LiveProxy.scala
+++ b/app/com/gu/viewer/proxy/LiveProxy.scala
@@ -16,4 +16,10 @@ class LiveProxy @Inject() (proxyClient: Proxy) extends Loggable {
     proxyClient.get(url)()
   }
 
+  def proxyPost(request: LiveProxyRequest) = ProxyResult.resultFrom {
+    val url = s"${request.protocol}://$serviceHost/${request.servicePath}"
+    log.info(s"Live POST Proxy to: $url")
+    proxyClient.post(destination = url, body = request.body.getOrElse(Map.empty))()
+  }
+
 }

--- a/app/com/gu/viewer/proxy/PreviewProxy.scala
+++ b/app/com/gu/viewer/proxy/PreviewProxy.scala
@@ -70,7 +70,7 @@ class PreviewProxy @Inject() (proxyClient: Proxy) extends Loggable {
   private def doPreviewProxy(request: PreviewProxyRequest) = {
 
     val url = s"${request.protocol}://$serviceHost/${request.servicePath}"
-    log.info(s"Proxy to preview: $url")
+    log.info(s"Proxy GET to preview: $url")
 
     def isLoginRedirect(response: ProxyResponse) = {
       response.status == 303 &&
@@ -88,7 +88,7 @@ class PreviewProxy @Inject() (proxyClient: Proxy) extends Loggable {
   private def doPreviewProxyPost(request: PreviewProxyRequest) = {
 
     val url = s"${request.protocol}://$serviceHost/${request.servicePath}"
-    log.info(s"Proxy to preview: $url")
+    log.info(s"Proxy POST to preview: $url")
 
     def isLoginRedirect(response: ProxyResponse) = {
       response.status == 303 &&
@@ -108,6 +108,7 @@ class PreviewProxy @Inject() (proxyClient: Proxy) extends Loggable {
    * Entry-point for proxying a request to preview
    */
   def proxy(request: PreviewProxyRequest): Future[Result] = ProxyResult.resultFrom {
+    log.info(s"Recieved proxy request for: ${request.requestUri}")
     request.session.sessionCookie -> request.session.authCookie match {
       case (Some(_), Some(_)) => doPreviewProxy(request)
       case _ => doPreviewAuth(request)
@@ -115,6 +116,8 @@ class PreviewProxy @Inject() (proxyClient: Proxy) extends Loggable {
   }
 
   def proxyPost(request: PreviewProxyRequest): Future[Result] = ProxyResult.resultFrom {
+    log.info(s"Recieved proxy POST request for: ${request.requestUri}")
+
     request.session.sessionCookie -> request.session.authCookie match {
       case (Some(_), Some(_)) => doPreviewProxyPost(request)
       case _ => doPreviewAuth(request)

--- a/app/com/gu/viewer/proxy/PreviewProxy.scala
+++ b/app/com/gu/viewer/proxy/PreviewProxy.scala
@@ -108,7 +108,7 @@ class PreviewProxy @Inject() (proxyClient: Proxy) extends Loggable {
    * Entry-point for proxying a request to preview
    */
   def proxy(request: PreviewProxyRequest): Future[Result] = ProxyResult.resultFrom {
-    log.info(s"Recieved proxy request for: ${request.requestUri}")
+    log.info(s"Received proxy request for: ${request.requestUri}")
     request.session.sessionCookie -> request.session.authCookie match {
       case (Some(_), Some(_)) => doPreviewProxy(request)
       case _ => doPreviewAuth(request)
@@ -116,7 +116,7 @@ class PreviewProxy @Inject() (proxyClient: Proxy) extends Loggable {
   }
 
   def proxyPost(request: PreviewProxyRequest): Future[Result] = ProxyResult.resultFrom {
-    log.info(s"Recieved proxy POST request for: ${request.requestUri}")
+    log.info(s"Received proxy POST request for: ${request.requestUri}")
 
     request.session.sessionCookie -> request.session.authCookie match {
       case (Some(_), Some(_)) => doPreviewProxyPost(request)

--- a/conf/routes
+++ b/conf/routes
@@ -14,7 +14,10 @@ GET        /live/*path                    com.gu.viewer.controllers.Application.
 
 
 GET        /proxy/preview/*path           com.gu.viewer.controllers.Proxy.proxy(service="preview", path)
+POST       /proxy/preview/*path           com.gu.viewer.controllers.Proxy.proxy(service="preview", path)
+
 GET        /proxy/live/*path              com.gu.viewer.controllers.Proxy.proxy(service="live", path)
+POST       /proxy/live/*path              com.gu.viewer.controllers.Proxy.proxy(service="live", path)
 
 
 # Long life cache for statically versioned font assets
@@ -27,3 +30,5 @@ GET        /assets/*file                  controllers.Assets.versioned(path="/pu
 GET        /robots.txt                    controllers.Assets.at(path="/public", file="robots.txt", aggressiveCaching: Boolean = false)
 
 GET        /*path                         com.gu.viewer.controllers.Proxy.redirectRelative(path)
+POST       /*path                         com.gu.viewer.controllers.Proxy.catchRelativePost(path)
+

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/guardian/editorial-viewer#readme",
   "dependencies": {
     "eslint": "^1.1.0",
-    "jspm": "0.16.11",
+    "jspm": "0.16.32",
     "node-sass": "^3.2.0"
   },
   "jspm": {


### PR DESCRIPTION
Quiz submissions require POST requests to function correctly, this adds POST support to the Live and Preview proxy requests. Forwarding a form encoded body on to host and returning the result.

The main difference between this and the GET handling is with the catchall route. Instead of triggering a 303 as done for GET requests this actually returns the correct host response on the incorrect url, this is due to browsers responding to a POST 303 with a GET.
