### PR TITLE
Updated to new training-preview domain name for CODE

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -54,7 +54,7 @@ liveHost.PROD="www.theguardian.com"
 mixpanel.PROD="d7f800e4a32e7b641dc2c5aa3bcc5e6b"
 composerReturnUri.PROD="https://composer.gutools.co.uk/find-by-path"
 
-previewHost.CODE="training.preview.gutools.co.uk"
+previewHost.CODE="training-preview.gutools.co.uk"
 previewHostForceHTTP.CODE=true
 liveHost.CODE="www.code.dev-theguardian.com"
 mixpanel.CODE="9f6b886760058c619d2a0b8e4fd3ba04"


### PR DESCRIPTION
Changes to proxy to: http://training-preview.gutools.co.uk https://training-preview.gutools.co.uk
