### PR TITLE
Enable to run the previewer locally with profile credentials

### DIFF
--- a/app/com/gu/viewer/controllers/PanDomainAuthActions.scala
+++ b/app/com/gu/viewer/controllers/PanDomainAuthActions.scala
@@ -2,6 +2,8 @@ package com.gu.viewer.controllers
 
 import com.gu.pandomainauth.action.AuthActions
 import com.gu.pandomainauth.model.AuthenticatedUser
+import com.amazonaws.auth._
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.gu.viewer.config.Configuration
 
 trait PanDomainAuthActions extends AuthActions {
@@ -17,4 +19,12 @@ trait PanDomainAuthActions extends AuthActions {
   override lazy val domain: String = Configuration.pandaDomain
 
   override lazy val system: String = "viewer"
+
+  override def awsCredentialsProvider: AWSCredentialsProvider =  new AWSCredentialsProviderChain(
+    new EnvironmentVariableCredentialsProvider,
+    new SystemPropertiesCredentialsProvider,
+    new ProfileCredentialsProvider("composer"),
+    new InstanceProfileCredentialsProvider
+  )
+
 }


### PR DESCRIPTION
I think I have covered most way to provide credentials - [as in ophan](https://github.com/guardian/ophan/blob/master/aws/src/main/scala/ophan/aws/ProfileAwareCredentialsProviderChain.scala).
From the cloudformation file, when deployed it seems to use `IamInstanceProfile` which should work.
