### PR TITLE
don’t break if no author tag

### DIFF
--- a/public/javascript/components/viewer.js
+++ b/public/javascript/components/viewer.js
@@ -129,7 +129,7 @@ function enableSocialShare() {
             '<div class=\'header\'>' +
             '  <div class=\'title\'><span>' + ogTitle.content + '</span></div>' +
             '  <div class=\'desc\'>' + ogDesc.content + '</div>' +
-            '  <div class=\'author\'> theguardian.com | By ' + author.content  + '</div>' +
+            '  <div class=\'author\'> theguardian.com | By ' + (author ? author.content : 'unknown')  + '</div>' +
             ' </div>';
 
         viewerEl.contentDocument.body.appendChild(fbCard);


### PR DESCRIPTION
Fixes this error when accessing [article without author](https://viewer.gutools.co.uk/live/environment/bike-blog/2016/apr/12/no-more-hippies-and-explorers-lament-for-the-changed-world-of-cycling).
