### PR TITLE
Fix gallery copy-taste mode

### DIFF
--- a/public/styles/readerMode.css
+++ b/public/styles/readerMode.css
@@ -130,6 +130,6 @@ article .element-embed:before {
 }
 
 .gallery__figcaption {
-    position: relative;
+    position: relative !important;
     width: 100%;
 }

--- a/public/styles/readerMode.css
+++ b/public/styles/readerMode.css
@@ -128,3 +128,8 @@ article figure[itemprop~="video"]:before {
 article .element-embed:before {
     content: "Embed placeholder. To view embed switch to mobile or desktop views." !important;
 }
+
+.gallery__figcaption {
+    position: relative;
+    width: 100%;
+}


### PR DESCRIPTION
The new gallery caption positioning results in them not being visible for print (and therefore copy taste mode)

This is a quick fix in the meatime