### PR TITLE
Change previewHost.CODE to preview-code.gu-web.net

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -54,7 +54,7 @@ liveHost.PROD="www.theguardian.com"
 mixpanel.PROD="d7f800e4a32e7b641dc2c5aa3bcc5e6b"
 composerReturnUri.PROD="https://composer.gutools.co.uk/find-by-path"
 
-previewHost.CODE="training-preview.gutools.co.uk"
+previewHost.CODE="preview-code.gu-web.net"
 previewHostForceHTTP.CODE=true
 liveHost.CODE="www.code.dev-theguardian.com"
 mixpanel.CODE="9f6b886760058c619d2a0b8e4fd3ba04"


### PR DESCRIPTION
Dotcom: training-preview.gutools.co.uk will be retired soon and replaced by Preview CODE

cc @jennysivapalan 