### PR TITLE
Update previewHost.CODE to preview.code.dev-gutools.co.uk

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -54,7 +54,7 @@ liveHost.PROD="www.theguardian.com"
 mixpanel.PROD="d7f800e4a32e7b641dc2c5aa3bcc5e6b"
 composerReturnUri.PROD="https://composer.gutools.co.uk/find-by-path"
 
-previewHost.CODE="preview-code.gu-web.net"
+previewHost.CODE="preview.code.dev-gutools.co.uk"
 previewHostForceHTTP.CODE=true
 liveHost.CODE="www.code.dev-theguardian.com"
 mixpanel.CODE="9f6b886760058c619d2a0b8e4fd3ba04"


### PR DESCRIPTION
There is a domain convention that if tool is found at `thetool.gutools.co.uk`
then a code version should be found at `thetool.code.dev-gutools.co.uk`.
This patch modify the previewHost.CODE url to follow this convention