### PR TITLE
Replace logstash with kinesis logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ Mobile first preview of Guardian content. [https://viewer.gutools.co.uk](https:/
 ## Set up Nginx
 Follow the [dev-nginx README](https://github.com/guardian/dev-nginx). There is an nginx mapping file in `nginx/`.
 
+## Dev configuration
+You'll need the private configuration information from the S3 bucket (`viewer-conf`) and put it `/etc/gu`:
+
+```
+    mkdir -p /etc/gu
+    aws s3 cp s3://viewer-conf/DEV/viewer.private.conf /etc/gu/viewer.private.conf --profile composer
+```
+
 ## Install client-side dependencies and build JS/CSS
 ```
 $ npm install

--- a/app/com/gu/viewer/aws/AWS.scala
+++ b/app/com/gu/viewer/aws/AWS.scala
@@ -7,20 +7,22 @@ import com.amazonaws.services.simpleemail._
 import com.amazonaws.util.EC2MetadataUtils
 import scala.collection.JavaConverters._
 
-object AWS {
+object AWS extends AwsInstanceTags {
 
   lazy val region = Region getRegion Regions.EU_WEST_1
 
   lazy val EC2Client = region.createClient(classOf[AmazonEC2Client], null, null)
 
-  lazy val instanceId = Option(EC2MetadataUtils.getInstanceId)
-
   lazy val emailClient = new AmazonSimpleEmailServiceClient()
   emailClient.setRegion(region)
+}
+
+trait AwsInstanceTags {
+  lazy val instanceId = Option(EC2MetadataUtils.getInstanceId)
 
   def readTag(tagName: String) = {
     instanceId.flatMap { id =>
-      val tagsResult = EC2Client.describeTags(
+      val tagsResult = AWS.EC2Client.describeTags(
         new DescribeTagsRequest().withFilters(
           new Filter("resource-type").withValues("instance"),
           new Filter("resource-id").withValues(id),
@@ -30,5 +32,4 @@ object AWS {
       tagsResult.getTags.asScala.find(_.getKey == tagName).map(_.getValue)
     }
   }
-
 }

--- a/app/com/gu/viewer/config/Configuration.scala
+++ b/app/com/gu/viewer/config/Configuration.scala
@@ -25,9 +25,6 @@ object Configuration {
   val mixpanel = getConfigString(s"mixpanel.$stage")
   val composerReturn = getConfigString(s"composerReturnUri.$stage")
 
-  val logstashEnabled = config.getBoolean("logstash.enabled").getOrElse(false)
-  val logstashDestination = config.getString("logstash.destination")
-
   def pandaDomain = {
     if (stage == "PROD") {
       "gutools.co.uk"

--- a/app/com/gu/viewer/logging/Loggable.scala
+++ b/app/com/gu/viewer/logging/Loggable.scala
@@ -1,10 +1,8 @@
 package com.gu.viewer.logging
 
-import java.security.SecureRandom
-
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.classic.{Logger => LogbackLogger}
-import com.amazonaws.auth.{InstanceProfileCredentialsProvider, STSAssumeRoleSessionCredentialsProvider}
+import com.amazonaws.auth.InstanceProfileCredentialsProvider
 import com.gu.logback.appender.kinesis.KinesisAppender
 import com.gu.viewer.aws.{AWS, AwsInstanceTags}
 import net.logstash.logback.layout.LogstashLayout
@@ -43,20 +41,10 @@ object Loggable extends AwsInstanceTags {
       appender.setStreamName(stream)
       appender.setContext(context)
       appender.setLayout(layout)
-      appender.setCredentialsProvider(buildCredentialsProvider())
+      appender.setCredentialsProvider(InstanceProfileCredentialsProvider.getInstance())
       appender.start()
 
       rootLogger.addAppender(appender)
     }
-  }
-
-  private def buildCredentialsProvider() = {
-    val stsRole = config.getString(s"$loggingPrefix.stsRoleToAssume").get
-
-    val random = new SecureRandom()
-    val sessionId = s"session${random.nextDouble()}"
-
-    val instanceProvider = new InstanceProfileCredentialsProvider()
-    new STSAssumeRoleSessionCredentialsProvider(instanceProvider, stsRole, sessionId)
   }
 }

--- a/app/com/gu/viewer/logging/Loggable.scala
+++ b/app/com/gu/viewer/logging/Loggable.scala
@@ -1,52 +1,62 @@
 package com.gu.viewer.logging
 
-import ch.qos.logback.classic.{Logger => LogbackLogger, LoggerContext}
-import ch.qos.logback.core.util.Duration
-import com.gu.viewer.config.Configuration
-import net.logstash.logback.appender.LogstashTcpSocketAppender
-import net.logstash.logback.encoder.LogstashEncoder
-import org.slf4j.{Logger => SLFLogger, LoggerFactory}
+import java.security.SecureRandom
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.{Logger => LogbackLogger}
+import com.amazonaws.auth.{InstanceProfileCredentialsProvider, STSAssumeRoleSessionCredentialsProvider}
+import com.gu.logback.appender.kinesis.KinesisAppender
+import com.gu.viewer.aws.{AWS, AwsInstanceTags}
+import net.logstash.logback.layout.LogstashLayout
+import org.slf4j.{LoggerFactory, Logger => SLFLogger}
 import play.api.{Logger => PlayLogger}
-import play.api.libs.json.Json
 
 
 trait Loggable {
   val log = play.api.Logger(getClass)
 }
 
-object Loggable {
-  lazy val rootLogger = LoggerFactory.getLogger(SLFLogger.ROOT_LOGGER_NAME).asInstanceOf[LogbackLogger]
+object Loggable extends AwsInstanceTags {
+  val rootLogger = LoggerFactory.getLogger(SLFLogger.ROOT_LOGGER_NAME).asInstanceOf[LogbackLogger]
 
-  val customFields = Map[String, String](
-    "app" -> Configuration.app,
-    "stage" -> Configuration.stage,
-    "stack" -> Configuration.stack
-  )
+  import play.api.Play.current
+  val config = play.api.Play.configuration
+  val loggingPrefix = "aws.kinesis.logging"
 
-  private def makeEncoder(context: LoggerContext) = {
-    val e = new LogstashEncoder()
-    e.setContext(context)
-    e.setCustomFields(Json.toJson(customFields).toString())
-    e.start()
-    e
-  }
+  def init() = {
+    for {
+      stack <- readTag("Stack")
+      app <- readTag("App")
+      stage <- readTag("Stage")
+      stream <- config.getString(s"$loggingPrefix.streamName")
+    } yield {
+      val context = rootLogger.getLoggerContext
 
-  private def makeTcpAppender(context: LoggerContext, destination: String) = {
-    val a = new LogstashTcpSocketAppender()
-    a.setContext(context)
-    a.setEncoder(makeEncoder(context))
-    a.setKeepAliveDuration(Duration.buildBySeconds(30.0))
-    a.addDestination(destination)
-    a.start()
-    a
-  }
+      val layout = new LogstashLayout()
+      layout.setContext(context)
+      layout.setCustomFields(s"""{"stack":"$stack","app":"$app","stage":"$stage"}""")
+      layout.start()
 
-  def init() = (Configuration.logstashEnabled, Configuration.logstashDestination) match {
-    case (true, Some(dest)) => {
-      PlayLogger.info("Initialising logstash tcp appender")
-      rootLogger.addAppender(makeTcpAppender(rootLogger.getLoggerContext, dest))
-      PlayLogger.info("Logstash tcp appender initialised")
+      val appender = new KinesisAppender[ILoggingEvent]()
+      appender.setBufferSize(1000)
+      appender.setRegion(AWS.region.getName)
+      appender.setStreamName(stream)
+      appender.setContext(context)
+      appender.setLayout(layout)
+      appender.setCredentialsProvider(buildCredentialsProvider())
+      appender.start()
+
+      rootLogger.addAppender(appender)
     }
-    case _ => PlayLogger.info("Logstash disabled or not configured")
+  }
+
+  private def buildCredentialsProvider() = {
+    val stsRole = config.getString(s"$loggingPrefix.stsRoleToAssume").get
+
+    val random = new SecureRandom()
+    val sessionId = s"session${random.nextDouble()}"
+
+    val instanceProvider = new InstanceProfileCredentialsProvider()
+    new STSAssumeRoleSessionCredentialsProvider(instanceProvider, stsRole, sessionId)
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk" % "1.10.10",
   "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.2.8",
   "net.logstash.logback" % "logstash-logback-encoder" % "4.5.1",
+  "com.gu" % "kinesis-logback-appender" % "1.3.0",
   ws
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ scalaVersion := "2.11.6"
 resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-java-sdk" % "1.10.10",
+  "com.amazonaws" % "aws-java-sdk" % "1.11.86",
   "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.2.8",
   "net.logstash.logback" % "logstash-logback-encoder" % "4.5.1",
   "com.gu" % "kinesis-logback-appender" % "1.3.0",

--- a/cloudformation/editorial-viewer.json
+++ b/cloudformation/editorial-viewer.json
@@ -346,7 +346,13 @@
                 "#!/bin/bash -ev\n",
 
                 "/opt/features/gnm-ca/install.sh\n",
-                "/opt/features/native-packager/install.sh -b composer-dist -t tgz -s\n"
+                "/opt/features/native-packager/install.sh -b composer-dist -t tgz -s\n",
+                "mkdir /etc/gu\n",
+                "aws s3 cp 's3://atom-maker-conf/",
+                {
+                  "Ref": "Stage"
+                },
+                "/media-atom-maker.private.conf' /etc/gu\n"
               ]
             ]
           }

--- a/cloudformation/editorial-viewer.json
+++ b/cloudformation/editorial-viewer.json
@@ -38,6 +38,11 @@
     "CertificateArn": {
       "Description": "ARN of the SSL certificate for this service",
       "Type": "String"
+    },
+    "GithubTeamName": {
+      "Description": "Github team name, used for giving ssh access to members of the team.",
+      "Type": "String",
+      "Default": "Editorial-Tools-SSHAccess"
     }
   },
   "Mappings": {
@@ -138,6 +143,22 @@
         "Roles": [{"Ref": "ViewerRole"}]
       }
     },
+    "ViewerGetConfigPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ViewerGetConfigPolicy",
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": ["s3:GetObject"],
+              "Resource": ["arn:aws:s3:::viewer-conf/*"]
+            }
+          ]
+        },
+        "Roles": [{"Ref": "ViewerRole"}]
+      }
+    },
     "ViewerCloudwatchPolicy": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
@@ -152,6 +173,28 @@
           ]
         },
         "Roles": [{"Ref": "ViewerRole"}]
+      }
+    },
+    "LoggingKinesisStreamPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "LoggingKinesisStreamPolicy",
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Resource": [
+                "arn:aws:kinesis:*:*:stream/elk-*-KinesisStream-*"
+              ],
+              "Action": [
+                "kinesis:PutRecord",
+                "kinesis:PutRecords",
+                "kinesis:DescribeStream"
+              ],
+              "Effect": "Allow"
+            }
+          ]
+        },
+        "Roles": [{"Ref":"ViewerRole"}]
       }
     },
     "ViewerInstanceProfile": {
@@ -344,15 +387,26 @@
               "",
               [
                 "#!/bin/bash -ev\n",
-
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "/opt/features/ssh-keys/initialise-keys-and-cron-job.sh -l -b github-team-keys -t ",
+                      {
+                        "Ref": "GithubTeamName"
+                      },
+                      " || true\n"
+                    ]
+                  ]
+                },
                 "/opt/features/gnm-ca/install.sh\n",
                 "/opt/features/native-packager/install.sh -b composer-dist -t tgz -s\n",
                 "mkdir /etc/gu\n",
-                "aws s3 cp 's3://atom-maker-conf/",
+                "aws s3 cp 's3://viewer-conf/",
                 {
                   "Ref": "Stage"
                 },
-                "/media-atom-maker.private.conf' /etc/gu\n"
+                "/viewer.private.conf' /etc/gu\n"
               ]
             ]
           }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,69 +1,11 @@
 # This is the main configuration file for the application.
 # ~~~~~
 
-# Secret key
-# ~~~~~
-# The secret key is used to secure cryptographics functions.
-#
-# This must be changed for production, but we recommend not changing it in this file.
-#
-# See http://www.playframework.com/documentation/latest/ApplicationSecret for more details.
-play.crypto.secret = "d5b@td/yoV@U@^<3jrG6mWrawYVyzI2EROMCCdhDIZ0gZ_DJ_t?kPqRQNhs5MQGO"
-
 # The application languages
 # ~~~~~
 play.i18n.langs = [ "en" ]
 
-# Router
-# ~~~~~
-# Define the Router object to use for this application.
-# This router will be looked up first when the application is starting up,
-# so make sure this is the entry point.
-# Furthermore, it's assumed your route file is named properly.
-# So for an application router like `my.application.Router`,
-# you may need to define a router file `conf/my.application.routes`.
-# Default to Routes in the root package (and conf/routes)
-# play.http.router = my.application.Routes
-
-# Database configuration
-# ~~~~~
-# You can declare as many datasources as you want.
-# By convention, the default datasource is named `default`
-#
-# db.default.driver=org.h2.Driver
-# db.default.url="jdbc:h2:mem:play"
-# db.default.username=sa
-# db.default.password=""
-
-# Evolutions
-# ~~~~~
-# You can disable evolutions if needed
-# play.evolutions.enabled=false
-
-# You can disable evolutions for a specific datasource if necessary
-# play.evolutions.db.default.enabled=false
-
 # Global filters config
 play.http.filters=com.gu.viewer.Filters
 
-# Viewer application configuration
-# ~~~~~
-
-previewHost.PROD="preview.gutools.co.uk"
-liveHost.PROD="www.theguardian.com"
-mixpanel.PROD="d7f800e4a32e7b641dc2c5aa3bcc5e6b"
-composerReturnUri.PROD="https://composer.gutools.co.uk/find-by-path"
-
-previewHost.CODE="preview.code.dev-gutools.co.uk"
-previewHostForceHTTP.CODE=true
-liveHost.CODE="www.code.dev-theguardian.com"
-mixpanel.CODE="9f6b886760058c619d2a0b8e4fd3ba04"
-composerReturnUri.CODE="https://composer.code.dev-gutools.co.uk/find-by-path"
-
-previewHost.DEV="preview.gutools.co.uk"
-liveHost.DEV="www.theguardian.com"
-mixpanel.DEV="9f6b886760058c619d2a0b8e4fd3ba04"
-composerReturnUri.DEV="https://composer.local.dev-gutools.co.uk/find-by-path"
-
-logstash.destination="ingest.logs.gutools.co.uk:6379"
-logstash.enabled=true
+include file("/etc/gu/viewer.private.conf")


### PR DESCRIPTION
Move the logging (https://logs.gutools.co.uk) to be sent over a kinesis stream rather than logstash. This is part of wider work to enable us to upgrade our ELK stack.

I had to upgrade the AWS client libraries in order to add a dependency on the kinesis logback appender. I've tested the app in CODE by viewing a composer article.

I've also moved some configuration containing secrets out of application.conf and into S3 buckets. The README has been updated with the instructions to get dev config.

I've also added the GitHub team keys to the cloud formation.

I'll use the [BFG](https://rtyley.github.io/bfg-repo-cleaner/) to scrub the repo of the secrets once this PR is merged.