### PR TITLE
Download S3 config before installing service

### DIFF
--- a/cloudformation/editorial-viewer.json
+++ b/cloudformation/editorial-viewer.json
@@ -400,13 +400,13 @@
                   ]
                 },
                 "/opt/features/gnm-ca/install.sh\n",
-                "/opt/features/native-packager/install.sh -b composer-dist -t tgz -s\n",
                 "mkdir /etc/gu\n",
                 "aws s3 cp 's3://viewer-conf/",
                 {
                   "Ref": "Stage"
                 },
-                "/viewer.private.conf' /etc/gu\n"
+                "/viewer.private.conf' /etc/gu\n",
+                "/opt/features/native-packager/install.sh -b composer-dist -t tgz -s\n"
               ]
             ]
           }


### PR DESCRIPTION
Follow up PR to #63.

During the PROD deploy, one of the machines failed to start correctly because it couldn't read the configuration that was moved into a separate secrets file. I believe this was because it was downloaded from S3 after the command to install the service was run.

This PR switches them around so the config is downloaded before installing the service.