### PR TITLE
Fix preview URL for android

### DIFF
--- a/app/com/gu/viewer/controllers/Email.scala
+++ b/app/com/gu/viewer/controllers/Email.scala
@@ -41,7 +41,7 @@ class Email extends Controller with Loggable with PanDomainAuthActions {
 
   private def formatEmail(path: String): String = {
     s"""iOS: https://entry.mobile-apps.guardianapis.com/deeplink/items/$path
-      |Android: http://preview.mobile-apps.guardianapis.com/items/$path
+      |Android: https://mobile-preview.guardianapis.com/items/$path
       |
       |
       |If you were not expecting this email please contact: digitalcms.dev@guardian.co.uk""".stripMargin


### PR DESCRIPTION
This is to point to the correct server as we don't need to support that legacy URL anymore.