### PR TITLE
Add noreferrer and noopener to _blank links

### DIFF
--- a/public/javascript/components/viewer.js
+++ b/public/javascript/components/viewer.js
@@ -254,6 +254,7 @@ function addBlankToLinks() {
         // If href doesn't contain gutools or theguardian (i.e: links to guardian pages) add blank
         if (!/gutools|theguardian/.test(ancs[i].origin)) {
             ancs[i].setAttribute('target', '_blank');
+            ancs[i].setAttribute('rel', 'noopener noreferrer');
         }
     }
 }


### PR DESCRIPTION
I realised that I accidentally introduced a slight [security (phishing) risk](https://mathiasbynens.github.io/rel-noopener/) with the `_blank` stuff I added, this fixes that and adds `noreferrer` so we don't leak referral details from viewer.