### PR TITLE
Bump panda version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk" % "1.11.86",
-  "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.2.8",
+  "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.5.1",
   "net.logstash.logback" % "logstash-logback-encoder" % "4.5.1",
   "com.gu" % "kinesis-logback-appender" % "1.3.0",
   ws


### PR DESCRIPTION
This is so it can read the asymmetric cookie introduced in 2015 (!) https://github.com/guardian/pan-domain-authentication/pull/11. Once all tools can read this cookie we can remove support for the old legacy cookie entirely.

There's a PR open for a full Play 2.6 and libraries upgrade (https://github.com/guardian/editorial-viewer/pull/76) but this smaller change will let us press ahead with the panda changes.

