### PR TITLE
don't require csrf for POST

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -32,5 +32,7 @@ GET        /assets/*file                  controllers.Assets.versioned(path="/pu
 GET        /robots.txt                    controllers.Assets.at(path="/public", file="robots.txt", aggressiveCaching: Boolean = false)
 
 GET        /*path                         com.gu.viewer.controllers.Proxy.redirectRelative(path)
+
++nocsrf
 POST       /*path                         com.gu.viewer.controllers.Proxy.catchRelativePost(path)
 


### PR DESCRIPTION
Not entirely sure why this is suddenly an issue ([I suspect a Play upgrade](https://www.playframework.com/documentation/2.7.x/ScalaCsrf#Applying-a-global-CSRF-filter)), but when trying to submit the quiz on `/preview/global/2019/oct/01/5d9302478f08fbb0c171e908`, the logs complain about CSRF.

```console
[warn] - play.filters.CSRF - [CSRF] Check failed because no or invalid token found in body for /atom/quiz/84f63876-2b80-479b-ae17-d2166c5a55df/global/2019/oct/01/5d9302478f08fbb0c171e908
[warn] - play.filters.CSRF - [CSRF] Check failed with NoTokenInBody for /atom/quiz/84f63876-2b80-479b-ae17-d2166c5a55df/global/2019/oct/01/5d9302478f08fbb0c171e908
[info] - com.gu.viewer.logging.RequestLoggingFilter - POST /atom/quiz/84f63876-2b80-479b-ae17-d2166c5a55df/global/2019/oct/01/5d9302478f08fbb0c171e908 took 79ms and returned 403
```