### PR TITLE
sandbox the iframe to restrict cookies

### DIFF
--- a/app/com/gu/viewer/views/viewer.scala.html
+++ b/app/com/gu/viewer/views/viewer.scala.html
@@ -57,7 +57,27 @@
 
     <div class="content">
         <div class="viewers">
-            <iframe id="viewer" class="viewer is-mobile-portrait" src="@viewerUrl#noads"></iframe>
+            @*
+                We sandbox the iframe to prevent external cookies being set on the Viewer domain.
+                We don't control the cookies set on theguardian.com.
+                This can be a problem as Play will reject requests where the header exceeds 8k.
+                This results in a slightly cryptic response:
+                    `'431 Request Header Fields Too Large': HTTP header value exceeds the configured limit of 8192 characters`
+
+                Our recommended remediation to this issue is to clear cookies.
+
+                If we prevent the iframe from setting cookies on the Viewer domain,
+                we can be certain that we won't exceed the 8k limit as we only set small auth cookies.
+
+                We _could_ increase the 8k limit, however that's bad as:
+                  - most servers have an 8k limit, so we'd also need to ensure the ELB allows large headers
+                  - 8k is already huge, how high do we go?!
+
+                See https://stackoverflow.com/a/8623061/3868241
+                See https://www.playframework.com/documentation/2.6.x/SettingsAkkaHttp
+                See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe
+            *@
+            <iframe id="viewer" sandbox="allow-scripts allow-top-navigation allow-forms" class="viewer is-mobile-portrait" src="@viewerUrl#noads"></iframe>
         </div>
     </div>
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Sandbox the iframe to prevent external cookies being set on the Viewer domain.

We don't control the cookies set on theguardian.com. This can be a problem as Play will reject requests where the header exceeds 8k. This results in a slightly cryptic response to the user:

> '431 Request Header Fields Too Large': HTTP header value exceeds the configured limit of 8192 characters

Our recommended remediation to this issue is to clear cookies.

If we prevent the iframe from setting cookies on the Viewer domain, we can be fairly certain that we won't exceed the 8k limit as we only set small auth cookies.

Not quite healing the source, but certainly placing it in a cast.

Note: We _could_ increase the 8k limit, however that's bad as:
  - most servers have an 8k limit, so we'd also need to ensure the ELB allows large headers
  - 8k is already huge, how high do we go?!

See https://stackoverflow.com/a/8623061/3868241
See https://www.playframework.com/documentation/2.6.x/SettingsAkkaHttp
See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe

`allow-forms` as quizzes are forms. See https://github.com/guardian/editorial-viewer/pull/83.

Note: Initially I took an alternative approach to this, adding a [custom error handler](https://www.playframework.com/documentation/2.6.x/ScalaErrorHandling) to log which header and/or cookie was causing the request to exceed the 8k limit. However the error handler didn't seem to get invoked at the right time, Play (or Akka) had already parsed the request and returned the 431.

## How to test
- On master
  - Clear cookies for Viewer
  - Preview a page
  - Note how many cookies are set on the Viewer domain

- On this branch
  - Clear cookies for Viewer
  - Preview a page
  - Note how few cookies are set on the Viewer domain

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
A reduction in [431 errors in the logs](https://logs.gutools.co.uk/goto/f5f6ce02513d2c7ce97766b90ae9621d).

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
Cookies are yummy and they make the internet go round. That is, a failure to write a cookie _might_ break some features of theguardian.com, for example sign-in, however you're unlikely to do that in Preview anyway.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
n/a