### PR TITLE
Increase the max head value length

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,3 +75,5 @@ debianPackageDependencies := Seq("openjdk-8-jre-headless")
 maintainer := "Digital CMS <digitalcms.dev@guardian.co.uk>"
 packageSummary := "viewer"
 packageDescription := """wrapper over the preview mode to give different platform previews"""
+
+PlayKeys.devSettings += "play.server.akka.max-header-value-length" -> "16k"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -6,6 +6,12 @@ play {
     loader = AppLoader
   }
 
+  server {
+    akka {
+      max-header-value-length = 16k
+    }
+  }
+
   # The application languages
   # ~~~~~
   i18n.langs = [ "en" ]


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR increase the `max-header-value-length` to prevent users from experiencing an issues with `HTTP header value exceeds the configured limit of 8192 characters`. There is a [trello](https://trello.com/c/j2uC9LlY/894-viewer-http-header-value-exceeds-the-configured-limit-of-8192-characters) card featuring more details on this issue.

This PR will increase the limit to an arbitrary 16k but will not indicate the root of the issue, we will want to log and investigate which cookies are causing this problem so we can resolve any hidden issues.

The reason the dev setting is required in `build.sbt` is related to how the application is started in run mode. More details are available [here](https://www.playframework.com/documentation/2.7.x/ConfigFile#Using-with-the-run-command).

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
It is possible to synthesise the issue by running the following code in the browser console: 
```
const SIZE = 1000
const cookieValue = 'x'.repeat(SIZE)

for(let i=0; i<=8; i++){
  document.cookie = `test${i}=${cookieValue}`
} 
```
## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Users no longer experience issues related to the request header size.

