### PR TITLE
Adds preview redirect button to preview mode

### DIFF
--- a/app/com/gu/viewer/views/viewer.scala.html
+++ b/app/com/gu/viewer/views/viewer.scala.html
@@ -30,6 +30,7 @@
                         Get app preview link
                     <!--</li>-->
                     @if(previewEnv == "preview") {
+                        <li class="top-toolbar__button" data-redirect-preview="true">Having trouble? Try this<!--</li>-->
                         <li data-switchmode="social-share" class="top-toolbar__button is-always-visible"><i class="top-toolbar__icon--socialshare"></i>Social share<!--</li>-->
                         <li data-switchmode="reader" class="top-toolbar__button is-always-visible"><i class="top-toolbar__icon--copycheck"></i>Copy taste<!--</li>-->
                         <li class="top-toolbar__button--mobilecheck" data-toggledesktop="true"><i class="top-toolbar__icon--checkbox"></i>Mobile checked & verified<!--</li>-->

--- a/public/javascript/controllers/application.js
+++ b/public/javascript/controllers/application.js
@@ -55,6 +55,7 @@ function bindClicks() {
     buttonUtil.bindClickToAttributeName('toggledesktop', toggleDesktop);
     buttonUtil.bindClickToAttributeName('toggleads', toggleAds);
     buttonUtil.bindClickToModeUpdate('switchmode', updateMode);
+    buttonUtil.bindClickToAttributeName('redirect-preview', redirectToPreview);
     buttonUtil.bindClickToAttributeName('print', viewer.printViewer);
     buttonUtil.bindClickToAttributeName('app-preview', appPreview);
 }
@@ -112,6 +113,10 @@ function updateMode(newMode) {
     activeMode = newMode;
 
     updateViews();
+}
+
+function redirectToPreview() {
+    window.location="https://preview.gutools.co.uk/" + window.location.href.split('/preview/')[1] + "#noads"
 }
 
 function toggleDesktop() {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR adds a redirect button to viewer which will make it easier for users to navigate to the preview site when the tool is having trouble. Feedback on the wording is welcome.

This is intended to be a temporary fix until the problem is solved. We would also like to be able to display the button only when the issue occurs, but due to the urgency of this problem, this will be done in a separate PR. 

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
View a preview page through viewer i.e. https://viewer.local.dev-gutools.co.uk/preview/uk, observe the "Having trouble? Try this" button, click it to navigate to the preview view of the content.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Users have an easy way to preview their content when viewer isn't working correctly. 