### PR TITLE
Add logging field to track if legacy cookie exists

### DIFF
--- a/app/com/gu/viewer/logging/RequestLoggingFilter.scala
+++ b/app/com/gu/viewer/logging/RequestLoggingFilter.scala
@@ -86,6 +86,7 @@ class RequestLoggingFilter(materializer: Materializer, refresher: PanDomainAuthS
         val markerContext = MarkerContext(Markers.appendEntries(Map(
           "userId" -> userId,
           "headersLength" -> headersLength,
+          "includesLegacyPandaCookie" -> requestHeader.cookies.get("gutoolsAuth").isDefined
         ).asJava))
 
         log.info(s"${requestHeader.method} ${requestHeader.uri} " +


### PR DESCRIPTION
## What does this change?
A small change to track whether a user is sending a legacy cookie. This will be useful to determine the effectiveness of the changes to remove the legacy cookie from the header load seen by viewer.
