### PR TITLE
Add an additional selector for DCR external link decoration

### DIFF
--- a/public/javascript/components/viewer.js
+++ b/public/javascript/components/viewer.js
@@ -249,7 +249,7 @@ function disableAdBlock() {
 function addBlankToLinks() {
     var iframe = document.getElementById('viewer');
     var iframeDoc = iframe.contentDocument;
-    var ancs = iframeDoc.querySelectorAll('.js-article__body a');
+    var ancs = iframeDoc.querySelectorAll('.js-article__body a, .article-body-viewer-selector a');
     for (var i = 0; i < ancs.length; i++) {
         // If href doesn't contain gutools or theguardian (i.e: links to guardian pages) add blank
         if (!/gutools|theguardian/.test(ancs[i].origin)) {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Adds an additional selector for articles rendered by DCR instead of frontend, which I've added in https://github.com/guardian/dotcom-rendering/pull/2192. This is to fix an issue where external links in preview article bodies (rendered by DCR) are opened within the viewer iframe, but do not comply with the CSP.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Open an external link in an article supported by DCR (you can tell if the footer contains a `(modern)` label). [Example](https://www.theguardian.com/commentisfree/2020/dec/02/cautious-christmas-covid). It should load in a new tab. Links to other guardian content should continue to load within the viewer iframe.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
No error pages for users of composers who attempt to test out external links that are added to their content. They work fine once published, but it's a bit alarming.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
Risk of maintaining this loose contract with DCR has been considered. There was in fact a draft PR to solve this directly within DCR, which while possible was overly complex and probably not the right place to solve a viewer-specific requirement.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
N/A