### PR TITLE
Truncate twitter trail when it's likely to be truncated in twitter embeds

### DIFF
--- a/public/javascript/components/viewer.js
+++ b/public/javascript/components/viewer.js
@@ -143,20 +143,29 @@ function enableSocialShare() {
         viewerEl.contentDocument.body.appendChild(twHeader);
 
         /* Twitter card */
-        var twCardType = viewerEl.contentDocument.querySelector('meta[name=\'twitter:card\']');
-        var twImage = viewerEl.contentDocument.querySelector('meta[name=\'twitter:image\']');
-        var twTitle = viewerEl.contentDocument.querySelector('meta[name=\'twitter:title\']');
-        var twDesc = viewerEl.contentDocument.querySelector('meta[name=\'twitter:description\']');
+        const twCardType = viewerEl.contentDocument.querySelector('meta[name=\'twitter:card\']');
+        const twImageEl = viewerEl.contentDocument.querySelector('meta[name=\'twitter:image\']') || ogImage
+        const twTitleEl = viewerEl.contentDocument.querySelector('meta[name=\'twitter:title\']') || ogTitle
+        const twDescEl = viewerEl.contentDocument.querySelector('meta[name=\'twitter:description\']') || ogDesc
+
+        // Twitter tries to ensure that any trails it displays fit across two lines.
+        // In practice, this leads to a trail between roughly 114 - 140 characters in
+        // length. We truncate the description here to provide a conservative
+        // approximation.
+        const twitterTrailLimit = 114
+        const twDesc = twDescEl.content.length > twitterTrailLimit
+          ? (twDescEl.content.slice(0, twitterTrailLimit) + "…")
+          : twDescEl.content
 
         remove(viewerEl, 'twCard');
         var twCard = document.createElement('div');
         twCard.id = 'twCard';
         twCard.className = twCardType.content;
         twCard.innerHTML = '' +
-            '<div class=\'image\'><img src=\'' + (twImage ? twImage.content : ogImage.content) + '\'></img></div>' +
+            '<div class=\'image\'><img src=\'' + twImageEl.content + '\'></img></div>' +
             '<div class=\'header\'>' +
-            '  <div class=\'title\'>' + (twTitle ? twTitle.content : ogTitle.content) + '</div>' +
-            '  <div class=\'desc\'>' + (twDesc ? twDesc.content : ogDesc.content) + '</div>' +
+            '  <div class=\'title\'>' + twTitleEl.content + '</div>' +
+            '  <div class=\'desc\'>' + twDesc + '</div>' +
             '  <div class=\'author\'> theguardian.com </div>' +
             ' </div>';
 


### PR DESCRIPTION
## What does this change?

In 'social share', truncates the Twitter description when it's likely to be truncated in a card. In discussions w/ CP, approximate is better than nothing – see the comments in the code for detail, hopefully there's enough!

Before:
<img width="516" alt="Screenshot 2021-03-16 at 13 43 07" src="https://user-images.githubusercontent.com/7767575/111319746-3dfd7280-865e-11eb-9248-3e000ed57eb5.png">


After:
<img width="574" alt="Screenshot 2021-03-16 at 13 40 57" src="https://user-images.githubusercontent.com/7767575/111319715-36d66480-865e-11eb-801a-483500296219.png">

Actual:
<img width="517" alt="Screenshot 2021-03-16 at 13 42 33" src="https://user-images.githubusercontent.com/7767575/111319735-3c33af00-865e-11eb-8695-bca36b9e7d9e.png">

## How to test

Test locally or in CODE. Does 'social share' produce a trail that's closer to what will appear in a twitter card? Is the not-quite-right truncation good enough?

