### PR TITLE
Move Xenial AMI to Bionic as it is no longer being supported

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -11,7 +11,7 @@ deployments:
       type: ami-cloudformation-parameter
       parameters:
         amiTags:
-          Recipe: editorial-tools-xenial-java8
+          Recipe: editorial-tools-bionic-java8
           AmigoStage: PROD
           BuiltBy: amigo
         amiEncrypted: true


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Moves AMI from Xenial to Bionic because Xenial is no longer supported.

This has been deployed to CODE via RiffRaff and tested successfully.

Related card [here](https://trello.com/c/NLpikw2C/2330-update-xenial-amis-to-use-bionic).

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Deploy via RiffRaff to CODE and ensure it's working.