### PR TITLE
Upgrades SBT to 1.5.7 and Scala Play to 2.8.11

### DIFF
--- a/app/com/gu/viewer/proxy/PreviewProxy.scala
+++ b/app/com/gu/viewer/proxy/PreviewProxy.scala
@@ -16,7 +16,7 @@ class PreviewProxy(proxyClient: ProxyClient, config: AppConfig)(implicit ec: Exe
 
 
   private def loginCallbackUrl(request: PreviewProxyRequest) =
-    s"https://${request.requestHost}${routes.Proxy.previewAuthCallback()}"
+    s"https://${request.requestHost}${routes.Proxy.previewAuthCallback}"
 
 
   /**

--- a/app/com/gu/viewer/proxy/PreviewSession.scala
+++ b/app/com/gu/viewer/proxy/PreviewSession.scala
@@ -1,6 +1,6 @@
 package com.gu.viewer.proxy
 
-import play.api.mvc.{Cookie, Cookies, Session}
+import play.api.mvc.{Cookie, Cookies, Session, DefaultCookieHeaderEncoding}
 
 case class PreviewSession(sessionCookie: Option[String] = None,
                           authCookie: Option[String] = None,
@@ -37,7 +37,7 @@ case class PreviewSession(sessionCookie: Option[String] = None,
 
 }
 
-object PreviewSession {
+object PreviewSession extends DefaultCookieHeaderEncoding {
   private val COOKIE_PREVIEW_SESSION = "PLAY_SESSION"
   private val COOKIE_PREVIEW_AUTH = "GU_PV_AUTH"
 
@@ -64,8 +64,8 @@ object PreviewSession {
 
     val allCookies = (
 
-      extractCookies("Set-Cookie", Cookies.fromSetCookieHeader) ++
-      extractCookies("Cookie", Cookies.fromCookieHeader)
+      extractCookies("Set-Cookie", fromSetCookieHeader) ++
+      extractCookies("Cookie", fromCookieHeader)
 
     ).flatten.groupBy(_.name).mapValues(_.head.value)
 

--- a/app/com/gu/viewer/proxy/ProxyClient.scala
+++ b/app/com/gu/viewer/proxy/ProxyClient.scala
@@ -2,13 +2,16 @@ package com.gu.viewer.proxy
 
 import com.gu.viewer.config.AppConfig
 import play.api.libs.ws.WSClient
-import play.api.mvc.{Cookie, Cookies}
+import play.api.mvc.{Cookie, Cookies, DefaultCookieHeaderEncoding}
 import play.api.http.HeaderNames.{CONTENT_LENGTH, COOKIE, USER_AGENT}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
+import play.api.http.CookiesConfiguration
+import play.api.http.HttpConfiguration
 
-class ProxyClient(ws: WSClient, config: AppConfig)(implicit ec: ExecutionContext) {
+class ProxyClient(ws: WSClient, config: AppConfig)(implicit ec: ExecutionContext) extends DefaultCookieHeaderEncoding {
+
 
   private val TIMEOUT = 10000.millis
 
@@ -22,7 +25,7 @@ class ProxyClient(ws: WSClient, config: AppConfig)(implicit ec: ExecutionContext
              followRedirects: Boolean = false
              )(handler: PartialFunction[ProxyResponse, Future[ProxyResult]] = PartialFunction.empty): Future[ProxyResult] = {
 
-    val cookieHeader = if (cookies.nonEmpty) Some(COOKIE -> Cookies.encodeCookieHeader(cookies)) else None
+    val cookieHeader = if (cookies.nonEmpty) Some(COOKIE -> encodeCookieHeader(cookies)) else None
 
     val contentLengthHeader = if (body.nonEmpty) Some(CONTENT_LENGTH -> body.size.toString) else None
 

--- a/build.sbt
+++ b/build.sbt
@@ -25,21 +25,26 @@ lazy val root = (project in file("."))
      )
   )
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.12.15"
 
-val awsVersion = "1.11.821"
+val awsVersion = "1.12.129"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-ses" % awsVersion,
-  "com.gu" %% "pan-domain-auth-play_2-6" % "0.9.1",
+  "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.4",
   "net.logstash.logback" % "logstash-logback-encoder" % "4.5.1",
   "com.gu" % "kinesis-logback-appender" % "1.3.0",
   ws,
   "com.typesafe.play" %% "play-iteratees" % "2.6.1",
   "com.google.guava" % "guava" % "27.0-jre"
 )
+
+val jacksonVersion = "2.11.4"
+
+dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
+
 
 // Front-end assets config
 val bundle = taskKey[Pipeline.Stage]("JSPM bundle")

--- a/build.sbt
+++ b/build.sbt
@@ -43,8 +43,8 @@ libraryDependencies ++= Seq(
 
 val jacksonVersion = "2.11.4"
 
+//Necessary to override jackson-databind versions due to AWS and Play incompatibility
 dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
-
 
 // Front-end assets config
 val bundle = taskKey[Pipeline.Stage]("JSPM bundle")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,4 @@
 #Activator-generated Properties
 #Thu Aug 06 13:47:37 UTC 2015
 template.uuid=a91771f5-1745-4f51-b877-badeea610f64
-sbt.version=1.2.8
+sbt.version=1.5.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 libraryDependencies += "org.vafer" % "jdeb" % "1.6" artifacts (Artifact("jdeb", "jar", "jar"))
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.21")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.11")
 addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.4.4")
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.3")
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")


### PR DESCRIPTION
## What does this change?

This PR upgrades the Viewer SBT and Scala Play versions to the latest. This is necessary to mitigate [security issues identified in log4j2](https://github.com/sbt/sbt/releases/tag/v1.5.6).

This PR makes several changes:

- Upgrades SBT to v1.5.7
- Upgrades Scala Play to v2.8.11
- Upgrades AWS libraries to v1.12.129
- Performs necessary migration steps for these upgrade to work

[Editorial tools working document](https://docs.google.com/document/d/1nVKsXiEXLviHOMY1iQEoyacvN93_SYCQwsOFfaP-dxo/edit#heading=h.67pgv1awhai).

Complexity:
`jackson-databind` had dependency conflicts which required resolution. I believe this may have been improved by upgrades to Scala 2.13.x but there are dependencies which don't support it yet.

The conflict:
- `jackson-databind` -> AWS libraries and Play were using different version of `jackson-databind`. This was resulting in a runtime error which was overcome via [dependencyOverrides](https://www.scala-sbt.org/1.x/docs/Library-Management.html#Overriding+a+version) SBT feature.

## How to test

We should be able to test this works be deploying the changes to CODE or running locally. This should be a no-op from a user perspective. We would also expect areas such as logging to continue as before.

## How can we measure success?

Viewer is on the latest security patched versions of core dependencies.