### PR TITLE
forward panda cookie when proxying `preview` 🐼 

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -49,6 +49,7 @@ class AppComponents(context: Context)
     bucketName = config.pandaBucket,
     settingsFileKey = config.pandaSettingsFileKey
   )
+  val pandaCookieName = panDomainSettings.settings.cookieSettings.cookieName
 
   val requestLoggingFilter = new RequestLoggingFilter(materializer, panDomainSettings)
   override def httpFilters: Seq[EssentialFilter] = Seq(requestLoggingFilter, csrfFilter)
@@ -59,7 +60,7 @@ class AppComponents(context: Context)
 
   val applicationController = new Application(controllerComponents, config)
   val managementController = new Management(controllerComponents)
-  val proxyController = new Proxy(controllerComponents, previewProxy, liveProxy)
+  val proxyController = new Proxy(controllerComponents, previewProxy, liveProxy, pandaCookieName)
   val emailController = new Email(controllerComponents, wsClient, emailClient, config, panDomainSettings)
 
   override def router: Router = new Routes(

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -49,7 +49,6 @@ class AppComponents(context: Context)
     bucketName = config.pandaBucket,
     settingsFileKey = config.pandaSettingsFileKey
   )
-  val pandaCookieName = panDomainSettings.settings.cookieSettings.cookieName
 
   val requestLoggingFilter = new RequestLoggingFilter(materializer, panDomainSettings)
   override def httpFilters: Seq[EssentialFilter] = Seq(requestLoggingFilter, csrfFilter)
@@ -58,9 +57,9 @@ class AppComponents(context: Context)
   val liveProxy = new LiveProxy(proxyClient, config)
   val previewProxy = new PreviewProxy(proxyClient, config)
 
-  val applicationController = new Application(controllerComponents, config)
+  val applicationController = new Application(controllerComponents, wsClient, config, panDomainSettings)
   val managementController = new Management(controllerComponents)
-  val proxyController = new Proxy(controllerComponents, previewProxy, liveProxy, pandaCookieName)
+  val proxyController = new Proxy(controllerComponents, wsClient, previewProxy, liveProxy, config, panDomainSettings)
   val emailController = new Email(controllerComponents, wsClient, emailClient, config, panDomainSettings)
 
   override def router: Router = new Routes(

--- a/app/com/gu/viewer/controllers/Application.scala
+++ b/app/com/gu/viewer/controllers/Application.scala
@@ -28,6 +28,7 @@ class Application(val controllerComponents: ControllerComponents, config: AppCon
       case _ => config.liveHost
     }
     val actualUrl = s"$protocol://$viewerHost/$path"
+    // TODO rename viewerUrl to iframeSrc and ideally eliminate the proxy all together for preview (following https://github.com/guardian/frontend/pull/27012)
     val viewerUrl = routes.Proxy.proxy(target, path).path()
     val proxyBase = routes.Proxy.proxy(target, "").absoluteURL()
     val composerUrl = config.composerReturn + "/" + path

--- a/app/com/gu/viewer/controllers/Application.scala
+++ b/app/com/gu/viewer/controllers/Application.scala
@@ -1,15 +1,26 @@
 package com.gu.viewer.controllers
 
+import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
 import com.gu.viewer.config.AppConfig
 import com.gu.viewer.logging.Loggable
 import com.gu.viewer.views.html
+import play.api.libs.ws.WSClient
 import play.api.mvc._
 import play.filters.csrf.CSRF
 
-class Application(val controllerComponents: ControllerComponents, config: AppConfig)
-  extends BaseController with Loggable {
+class Application(
+  val controllerComponents: ControllerComponents,
+  val wsClient: WSClient,
+  val config: AppConfig,
+  val panDomainSettings: PanDomainAuthSettingsRefresher
+) extends BaseController with Loggable with PanDomainAuthActions {
 
-  def index = Action {
+  def oauthCallback: Action[AnyContent] =
+    Action.async { implicit request =>
+      processOAuthCallback()
+    }
+
+  def index = AuthAction {
     Redirect("/live/uk")
   }
 
@@ -21,7 +32,7 @@ class Application(val controllerComponents: ControllerComponents, config: AppCon
     viewer("live", path, "live")
   }
 
-  def viewer(target: String, path: String, previewEnv: String) = Action { implicit request =>
+  def viewer(target: String, path: String, previewEnv: String) = AuthAction { implicit request =>
     val protocol = if (request.secure) "https" else "http"
     val viewerHost = target match {
       case "preview" => config.previewHost

--- a/app/com/gu/viewer/controllers/Email.scala
+++ b/app/com/gu/viewer/controllers/Email.scala
@@ -10,10 +10,13 @@ import play.api.mvc._
 
 import scala.util.control.NonFatal
 
-class Email(val controllerComponents: ControllerComponents, val wsClient: WSClient,
-            emailClient: AmazonSimpleEmailService, val config: AppConfig,
-            val panDomainSettings: PanDomainAuthSettingsRefresher)
-  extends BaseControllerHelpers with Loggable with PanDomainAuthActions {
+class Email(
+  val controllerComponents: ControllerComponents,
+  val wsClient: WSClient,
+  emailClient: AmazonSimpleEmailService,
+  val config: AppConfig,
+  val panDomainSettings: PanDomainAuthSettingsRefresher
+) extends BaseControllerHelpers with Loggable with PanDomainAuthActions {
 
   def sendEmail(path: String) = APIAuthAction { req =>
     val email = req.user.email

--- a/app/com/gu/viewer/controllers/Proxy.scala
+++ b/app/com/gu/viewer/controllers/Proxy.scala
@@ -1,20 +1,27 @@
 package com.gu.viewer.controllers
 
+import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
+import com.gu.viewer.config.AppConfig
 import com.gu.viewer.logging.Loggable
 import com.gu.viewer.proxy._
-import play.api.mvc.{Action, BaseController, BaseControllerHelpers, ControllerComponents}
+import play.api.libs.ws.WSClient
+import play.api.mvc.{BaseController, ControllerComponents}
 
 import scala.concurrent.Future
 
 
 class Proxy(
   val controllerComponents: ControllerComponents,
+  val wsClient: WSClient,
   previewProxy: PreviewProxy,
   liveProxy: LiveProxy,
-  pandaCookieName: String
-) extends BaseController with Loggable {
+  val config: AppConfig,
+  val panDomainSettings: PanDomainAuthSettingsRefresher
+) extends BaseController with Loggable with PanDomainAuthActions {
 
-  def proxy(service: String, path: String) = Action.async { implicit request =>
+  private val pandaCookieName = panDomainSettings.settings.cookieSettings.cookieName
+
+  def proxy(service: String, path: String) = AuthAction.async { implicit request =>
 
     ProxyRequest(service, path, request) match {
       case r: PreviewProxyRequest => previewProxy.proxy(r.copy(maybePandaCookieToForward = request.cookies.get(pandaCookieName)))
@@ -23,25 +30,13 @@ class Proxy(
     }
   }
 
-  def proxyPost(service: String, path: String) = Action.async { implicit request =>
-
-    val body = request.body.asFormUrlEncoded
-
-    ProxyRequest(service, path, request, body) match {
-      case r: PreviewProxyRequest => previewProxy.proxyPost(r)
-      case r: LiveProxyRequest => liveProxy.proxyPost(r)
-      case UnknownProxyRequest => Future.successful(BadRequest(s"Unknown proxy service: $service"))
-    }
-  }
-
-
   /**
    * Preview Authentication callback.
    *
    * Proxy all request params and Preview session cookie to Preview authentication callback.
    * Store response cookies into Viewer's play session.
    */
-  def previewAuthCallback = Action.async { request =>
+  def previewAuthCallback = AuthAction.async { request =>
     previewProxy.previewAuthCallback(PreviewProxyRequest.authCallbackRequest(request))
   }
 
@@ -50,7 +45,7 @@ class Proxy(
    * Redirect requests to routes that don't exist which originate (Referer header)
    * from a proxied request. Catches server relative requests in a proxied response.
    */
-  def redirectRelative(path: String) = Action { request =>
+  def redirectRelative(path: String) = AuthAction { request =>
 
     val fromProxy = """^\w+:\/\/([^/]+)\/proxy\/([^/]+).*$""".r
     val host = request.host
@@ -65,7 +60,7 @@ class Proxy(
 
   /** We don't want to redirect for POST requests */
 
-  def catchRelativePost(path: String) = Action.async { implicit request =>
+  def catchRelativePost(path: String) = AuthAction.async { implicit request =>
 
     val fromProxy = """^\w+:\/\/([^/]+)\/proxy\/([^/]+).*$""".r
     val host = request.host

--- a/app/com/gu/viewer/controllers/Proxy.scala
+++ b/app/com/gu/viewer/controllers/Proxy.scala
@@ -7,13 +7,17 @@ import play.api.mvc.{Action, BaseController, BaseControllerHelpers, ControllerCo
 import scala.concurrent.Future
 
 
-class Proxy(val controllerComponents: ControllerComponents,
-            previewProxy: PreviewProxy, liveProxy: LiveProxy) extends BaseController with Loggable {
+class Proxy(
+  val controllerComponents: ControllerComponents,
+  previewProxy: PreviewProxy,
+  liveProxy: LiveProxy,
+  pandaCookieName: String
+) extends BaseController with Loggable {
 
   def proxy(service: String, path: String) = Action.async { implicit request =>
 
     ProxyRequest(service, path, request) match {
-      case r: PreviewProxyRequest => previewProxy.proxy(r)
+      case r: PreviewProxyRequest => previewProxy.proxy(r.copy(maybePandaCookieToForward = request.cookies.get(pandaCookieName)))
       case r: LiveProxyRequest => liveProxy.proxy(r)
       case UnknownProxyRequest => Future.successful(BadRequest(s"Unknown proxy service: $service"))
     }

--- a/app/com/gu/viewer/proxy/ProxyRequest.scala
+++ b/app/com/gu/viewer/proxy/ProxyRequest.scala
@@ -1,6 +1,6 @@
 package com.gu.viewer.proxy
 
-import play.api.mvc.RequestHeader
+import play.api.mvc.{Cookie, RequestHeader}
 
 
 sealed trait ProxyRequest
@@ -19,13 +19,15 @@ object ProxyRequest {
 
 case class LiveProxyRequest(servicePath: String, body: Option[Map[String, Seq[String]]] = None) extends ProxyRequest
 
-case class PreviewProxyRequest(servicePath: String,
-                               requestHost: String,
-                               requestUri: String,
-                               requestQueryString: Map[String, Seq[String]],
-                               session: PreviewSession,
-                               body: Option[Map[String, Seq[String]]] = None
-                              ) extends ProxyRequest
+case class PreviewProxyRequest(
+  servicePath: String,
+  requestHost: String,
+  requestUri: String,
+  requestQueryString: Map[String, Seq[String]],
+  session: PreviewSession,
+  body: Option[Map[String, Seq[String]]] = None,
+  maybePandaCookieToForward: Option[Cookie] = None
+) extends ProxyRequest
 
 object PreviewProxyRequest {
   def apply(servicePath: String, request: RequestHeader, body: Option[Map[String, Seq[String]]]): PreviewProxyRequest =

--- a/conf/routes
+++ b/conf/routes
@@ -2,6 +2,9 @@
 # This file defines all application routes (Higher priority routes first)
 # ~~~~
 
+# auth
+GET         /oauthCallback                com.gu.viewer.controllers.Application.oauthCallback
+
 # Home page
 GET        /                              com.gu.viewer.controllers.Application.index
 GET        /management/healthcheck        com.gu.viewer.controllers.Management.healthcheck


### PR DESCRIPTION
https://github.com/guardian/frontend/pull/27012 changes `preview` to use pan-domain-auth (rather than plain Google auth) for better resilience during Google outages. As it stands viewer proxies preview (rather than iframing preview in directly) - see https://github.com/guardian/editorial-viewer/pull/10.

Whilst we roll out https://github.com/guardian/frontend/pull/27012 we need to forward the panda cookie available to viewer* (because panda shares cookie across the top-level domain, i.e. `.local.dev-gutools.co.uk`, `.code.dev-gutools.co.uk`, or `.gutools.co.uk`) on to preview (otherwise it doesn't work) - whilst retaining the existing auth forwarding for the time being so there's no adverse user impact during the roll-out of https://github.com/guardian/frontend/pull/27012.

\* it turns out that most of the main viewer endpoints weren't themselves doing panda auth 😱  - so the second commit in this PR addresses that (the `oauthCallback` added has been registered in the Google console accordingly).

After that though the rationale for proxying preview (as hinted at in #10) and the complexity therein no longer stands... we should be able to simply use preview URLs in the viewer iframe. [`X-Frame-Options`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options) is now obsolete when trumped by the [`frame-ancestors`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors) directive of the `Content-Security-Policy` - fortunately preview already explicitly sets the `Content-Security-Policy` when serving its responses so we should be able to set `frame-ancestors` to allow-list viewer... and be able to delete lots of the proxying logic in viewer. I've added a `TODO` in this PR to hint at the entrypoint for such a refactor.