### PR TITLE
panda upgrade to v4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-ses" % awsVersion,
-  "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.6",
+  "com.gu" %% "pan-domain-auth-play_2-8" % "3.1.0",
   "net.logstash.logback" % "logstash-logback-encoder" % "7.2",
   ws,
   "com.google.guava" % "guava" % "27.0-jre"

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-ses" % awsVersion,
-  "com.gu" %% "pan-domain-auth-play_2-8" % "3.1.0",
+  "com.gu" %% "pan-domain-auth-play_2-8" % "4.0.0",
   "net.logstash.logback" % "logstash-logback-encoder" % "7.2",
   ws,
   "com.google.guava" % "guava" % "27.0-jre"


### PR DESCRIPTION
## What does this change?

Upgrades [pan-domain-authentication](https://github.com/guardian/pan-domain-authentication) to v4

This project did not make use of the archived  [panda-hmac)](https://github.com/guardian/panda-hmac), so did not need any other code changes to account for the breaking change for [v3](https://github.com/guardian/pan-domain-authentication/releases/tag/v3.0.0).

## How to test

running on CODE:

open  https://viewer.code.dev-gutools.co.uk/preview/world/article/2024/jul/08/article-on-code-for-testing-viewer - should display the preview.
open the same url in an incognito window (or other environment without your auth cookies) and you should be redirected to the google auth login screen


## How can we measure success?

There are future improvements planned for pan-domain-authentication - this upgrade will make it easier to apply them when released.

## Have we considered potential risks?

Should be a no-op change. If it works on CODE, should be reasonably sure will work on PROD.
