### PR TITLE
Revert "panda upgrade to v4"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-ses" % awsVersion,
-  "com.gu" %% "pan-domain-auth-play_2-8" % "4.0.0",
+  "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.6",
   "net.logstash.logback" % "logstash-logback-encoder" % "7.2",
   ws,
   "com.google.guava" % "guava" % "27.0-jre"


### PR DESCRIPTION
Reverts guardian/editorial-viewer#137

Change appeared to be working locally and on CODE, but failed after deploying to PROD:

example error:
message: ```Uncaught error from thread [application-pekko.actor.default-dispatcher-9]: 'void play.api.mvc.DiscardingCookie.<init>(java.lang.String, java.lang.String, scala.Option, boolean)', shutting down JVM since 'pekko.jvm-exit-on-fatal-error' is enabled for ActorSystem[application]```

Seems to relate to the use of this [class from the Pan-domain-auth library](https://github.com/guardian/pan-domain-authentication/blob/c451be84c2c304b705f23069fbfacc21c17e595e/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/action/Actions.scala) with editorial viewer.

This project lacks unit tests - ideally should get these in place before attempting a fix