### PR TITLE
panda upgrade

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-ses" % awsVersion,
-  "com.gu" %% "pan-domain-auth-play_2-8" % "4.0.0",
+  "com.gu" %% "pan-domain-auth-play_3-0" % "4.0.0",
   "net.logstash.logback" % "logstash-logback-encoder" % "7.2",
   ws,
   "com.google.guava" % "guava" % "27.0-jre"

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-ses" % awsVersion,
-  "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.6",
+  "com.gu" %% "pan-domain-auth-play_3-0" % "4.0.0",
   "net.logstash.logback" % "logstash-logback-encoder" % "7.2",
   ws,
   "com.google.guava" % "guava" % "27.0-jre"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

see https://github.com/guardian/editorial-viewer/pull/138 - attempted to upgrade the `"com.gu" %% "pan-domain-auth-play_2-8"`  to v4 before, but this project actually uses play 3 now - so the correct package should be `"com.gu" %% "pan-domain-auth-play_3-0"`

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

running on CODE:

open https://viewer.code.dev-gutools.co.uk/preview/world/article/2024/jul/08/article-on-code-for-testing-viewer - should display the preview.
open the same url in an incognito window (or other environment without your auth cookies) and you should be redirected to the google auth login screen

## How can we measure success?

There are future improvements planned for pan-domain-authentication - this upgrade will make it easier to apply them when released.

## Have we considered potential risks?

might fail on prod again
