### PR TITLE
Upgrade to Panda v7 - support key rotation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,9 @@ jobs:
           npm run webpack
           npm run sass
 
-      # Get the desired version of Java installed (also comes with the SBT tool)
-      - uses: actions/setup-java@v3
-        with:
-          distribution: 'corretto'
-          java-version: '11'
-          cache: 'sbt'
-    
+      - name: Setup Scala
+        uses: guardian/setup-scala@v1
+
       - name: Build and Test project, Assemble Debian package, copy to root dir
         run: |
           sbt clean compile test Debian/packageBin

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-11.0.24.8.1

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -4,7 +4,7 @@ import com.amazonaws.regions.Regions
 import com.amazonaws.services.ec2.{AmazonEC2, AmazonEC2ClientBuilder}
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import com.amazonaws.services.simpleemail.{AmazonSimpleEmailService, AmazonSimpleEmailServiceClientBuilder}
-import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
+import com.gu.pandomainauth.{PanDomainAuthSettingsRefresher, S3BucketLoader}
 import com.gu.viewer.aws.AwsInstanceTags
 import com.gu.viewer.config.AppConfig
 import com.gu.viewer.controllers.{Application, Email, Management, Proxy}
@@ -42,12 +42,10 @@ class AppComponents(context: Context)
   val tags = new AwsInstanceTags(ec2Client)
   val config = new AppConfig(tags, context.initialConfiguration)
 
-  val panDomainSettings: PanDomainAuthSettingsRefresher = new PanDomainAuthSettingsRefresher(
+  val panDomainSettings: PanDomainAuthSettingsRefresher = PanDomainAuthSettingsRefresher(
     domain = config.pandaDomain,
     system = "viewer",
-    s3Client = s3Client,
-    bucketName = config.pandaBucket,
-    settingsFileKey = config.pandaSettingsFileKey
+    S3BucketLoader.forAwsSdkV1(s3Client, "pan-domain-auth-settings")
   )
 
   val requestLoggingFilter = new RequestLoggingFilter(materializer, panDomainSettings)

--- a/app/com/gu/viewer/logging/RequestLoggingFilter.scala
+++ b/app/com/gu/viewer/logging/RequestLoggingFilter.scala
@@ -17,8 +17,8 @@ class RequestLoggingFilter(materializer: Materializer, refresher: PanDomainAuthS
 
   implicit val mat: Materializer = materializer
 
-  def readAuthenticatedUser(request: RequestHeader): Option[AuthenticatedUser] = readCookie(request) map { cookie =>
-    CookieUtils.parseCookieData(cookie.value, refresher.settings.publicKey)
+  def readAuthenticatedUser(request: RequestHeader): Option[AuthenticatedUser] = readCookie(request) flatMap { cookie =>
+    CookieUtils.parseCookieData(cookie.value, refresher.settings.signingAndVerification).toOption
   }
 
   def readCookie(request: RequestHeader): Option[Cookie] = request.cookies.get(refresher.settings.cookieSettings.cookieName)

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-ses" % awsVersion,
-  "com.gu" %% "pan-domain-auth-play_3-0" % "4.0.0",
+  "com.gu" %% "pan-domain-auth-play_3-0" % "7.0.0",
   "net.logstash.logback" % "logstash-logback-encoder" % "7.2",
   ws,
   "com.google.guava" % "guava" % "27.0-jre"


### PR DESCRIPTION
This upgrades Panda from v4 to v7, allowing us to use [key rotation](https://github.com/guardian/pan-domain-authentication/pull/150).

Follows the guidance from https://github.com/guardian/pan-domain-authentication/issues/160 and based on https://github.com/guardian/atom-workshop/pull/361

## Testing
