### PR TITLE
Bump scala to 2.13.9. Work around compiler error in conf/routes.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ lazy val root = (project in file("."))
      )
   )
 
-scalaVersion := "2.13.0"
+scalaVersion := "2.13.9"
 
 val awsVersion = "1.12.129"
 

--- a/conf/routes
+++ b/conf/routes
@@ -32,7 +32,7 @@ GET        /assets/fonts/v1/*file         controllers.Assets.at(path="/public/fo
 GET        /assets/*file                  controllers.Assets.versioned(path="/public", file: Asset)
 
 #Robots.txt
-GET        /robots.txt                    controllers.Assets.at(path="/public", file="robots.txt", aggressiveCaching: Boolean = false)
+GET        /robots.txt                    controllers.Assets.at(path="/public", file="robots.txt", aggressiveCaching: Boolean = true)
 
 GET        /*path                         com.gu.viewer.controllers.Proxy.redirectRelative(path)
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Upgrade Scala version with respect to issue https://github.com/guardian/editorial-viewer/issues/145.

Note that this version of Scala started complaining about an non-exhaustive match in our routes;

```
editorial-viewer/conf/routes:29:1: match may not be exhaustive.
[error] It would fail on the following input: (_, _, _)
[error] GET        /assets/fonts/v1/*file         controllers.Assets.at(path="/public/fonts/v1", file, aggressiveCaching: Boolean = true)
```

Through some trial and error @jonathonherbert and I got it to compile but only by using a consistent value for `aggressiveCaching`, and we concluded that it was safer to allow a long-term caching of `robots.txt` rather than relax the caching of fonts specifically, or delay the Scala update while we tried to figure out why it had become a problem since Scala 2.13.0.

I hear that @davidfurey is knowledgeable about such things so perhaps we could learn what's up with this, and how to fix it  from you. 

In the meantime, does it hurt to have a long-term cached version of `robots.txt`, which is just instructing bots not to crawl it anyway, for an application that has minimal public Internet exposure?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

If there is a CODE environment we can deploy to, we can do that. Realistically though, if it compiles and builds we should be fairly confident that no other behaviour is expected to change as a result of this PR.

## How can we measure success?

Fewer critical vulnerability warnings? Success!

## Have we considered potential risks?

It _could_ break completely, I guess. In which case redeploying the last known good build and reverting to take stock seems reasonable.

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
-   [x] N/A - There are no visual changes here

