### PR TITLE
Add gu-cmp-disabled cookie to preview requests

### DIFF
--- a/app/com/gu/viewer/proxy/PreviewProxy.scala
+++ b/app/com/gu/viewer/proxy/PreviewProxy.scala
@@ -17,10 +17,10 @@ class PreviewProxy(proxyClient: ProxyClient, config: AppConfig)(implicit ec: Exe
   /**
    * Get a cookie that disables the consent management platform banner for theguardian.com.
    */
-  private def disableCmpCookie = Cookie(
+  private def getDisableCmpCookie(domain: String) = Cookie(
     name = "gu-cmp-disabled",
     value = "true",
-    domain = Some(serviceHost),
+    domain = Some(domain),
   )
 
   private def loginCallbackUrl(request: PreviewProxyRequest) =
@@ -73,7 +73,6 @@ class PreviewProxy(proxyClient: ProxyClient, config: AppConfig)(implicit ec: Exe
 
 
   private def doPreviewProxy(request: PreviewProxyRequest) = {
-
     val url = s"https://$serviceHost/${request.servicePath}"
     log.info(s"Proxy GET to preview: $url")
 
@@ -86,7 +85,7 @@ class PreviewProxy(proxyClient: ProxyClient, config: AppConfig)(implicit ec: Exe
     proxyClient.get(url, cookies = cookies) {
       case response if isLoginRedirect(response) => doPreviewAuth(request)
       // Add the cookie to disable the consent management platform for GET requests
-      case response => Future.successful(ProxyResultWithBody(response, List(disableCmpCookie)))
+      case response => Future.successful(ProxyResultWithBody(response, List(getDisableCmpCookie(request.requestHost))))
     }
   }
 

--- a/app/com/gu/viewer/proxy/PreviewProxy.scala
+++ b/app/com/gu/viewer/proxy/PreviewProxy.scala
@@ -21,6 +21,7 @@ class PreviewProxy(proxyClient: ProxyClient, config: AppConfig)(implicit ec: Exe
     name = "gu-cmp-disabled",
     value = "true",
     domain = Some(domain),
+    httpOnly = false
   )
 
   private def loginCallbackUrl(request: PreviewProxyRequest) =

--- a/app/com/gu/viewer/proxy/ProxyResult.scala
+++ b/app/com/gu/viewer/proxy/ProxyResult.scala
@@ -2,17 +2,18 @@ package com.gu.viewer.proxy
 
 import com.gu.viewer.logging.Loggable
 import com.gu.viewer.views.html
+import play.api.http.CookiesConfiguration
 import play.api.http.HeaderNames._
 import play.api.http.MimeTypes._
 import play.api.mvc.Results._
-import play.api.mvc.Result
+import play.api.mvc.{Cookie, CookieHeaderEncoding, Cookies, Result}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 
 sealed trait ProxyResult
 
-case class ProxyResultWithBody(response: ProxyResponse) extends ProxyResult
+case class ProxyResultWithBody(response: ProxyResponse, CookiesToSet: List[Cookie] = List.empty) extends ProxyResult
 
 case class RedirectProxyResult(location: String) extends ProxyResult
 
@@ -21,17 +22,18 @@ case class RedirectProxyResultWithSession(location: String, session: PreviewSess
 case class PreviewAuthRedirectProxyResult(location: String, session: PreviewSession) extends ProxyResult
 
 
-object ProxyResult extends Loggable {
+object ProxyResult extends Loggable with CookieHeaderEncoding {
+  protected def config: CookiesConfiguration = CookiesConfiguration(strict = true)
 
   /**
    * Convert ProxyResult to a Play Result
    */
-  def asResult(proxyResult: ProxyResult): Result = proxyResult match {
-
+  private def asResult(proxyResult: ProxyResult): Result = proxyResult match {
     // Stream body result
-    case ProxyResultWithBody(response) => {
+    case ProxyResultWithBody(response, cookiesToSet) => {
       val resultHeaders = Seq(
-        response.header(CONTENT_LENGTH).map(CONTENT_LENGTH -> _)
+        response.header(CONTENT_LENGTH).map(CONTENT_LENGTH -> _),
+        Some(SET_COOKIE -> encodeSetCookieHeader(cookiesToSet))
       ).flatten
 
       Status(response.status)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Add the `gu-cmp-disabled` cookie to prevent consent banner from appearing in preview. Editorial have to accept cookies before previewing a page which is inconvenient. 

https://trello.com/c/hZCJ8y4q
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Running locally or in CODE, remove all cookies for `viewer.${stage}` and load a preview page, e.g. [this piece.](https://viewer.code.dev-gutools.co.uk/preview/technology/2020/jul/02/whatsapp-groups-conspiracy-theories-disinformation-democracy) Consent banners should not appear.

Tested in CODE, works as expected, and we can see the relevant cookie being picked up by the CMP code:

<img width="1554" alt="Screenshot 2025-03-26 at 09 49 40" src="https://github.com/user-attachments/assets/60dbe2db-3b0d-45fb-885f-f3317c506dfa" />


