### PR TITLE
Revert "Add gu-cmp-disabled cookie to preview requests"

### DIFF
--- a/app/com/gu/viewer/proxy/PreviewProxy.scala
+++ b/app/com/gu/viewer/proxy/PreviewProxy.scala
@@ -3,7 +3,7 @@ package com.gu.viewer.proxy
 import com.gu.viewer.config.AppConfig
 import com.gu.viewer.controllers.routes
 import com.gu.viewer.logging.Loggable
-import play.api.mvc.{Cookie, Result}
+import play.api.mvc.Result
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -14,18 +14,10 @@ class PreviewProxy(proxyClient: ProxyClient, config: AppConfig)(implicit ec: Exe
   val serviceHost = config.previewHost
   val previewLoginUrl = s"https://$serviceHost/login"
 
-  /**
-   * Get a cookie that disables the consent management platform banner for theguardian.com.
-   */
-  private def getDisableCmpCookie(domain: String) = Cookie(
-    name = "gu-cmp-disabled",
-    value = "true",
-    domain = Some(domain),
-    httpOnly = false
-  )
 
   private def loginCallbackUrl(request: PreviewProxyRequest) =
     s"https://${request.requestHost}${routes.Proxy.previewAuthCallback}"
+
 
   /**
    * Transform proxy server relative URI to viewer URI.
@@ -74,6 +66,7 @@ class PreviewProxy(proxyClient: ProxyClient, config: AppConfig)(implicit ec: Exe
 
 
   private def doPreviewProxy(request: PreviewProxyRequest) = {
+
     val url = s"https://$serviceHost/${request.servicePath}"
     log.info(s"Proxy GET to preview: $url")
 
@@ -85,9 +78,8 @@ class PreviewProxy(proxyClient: ProxyClient, config: AppConfig)(implicit ec: Exe
 
     proxyClient.get(url, cookies = cookies) {
       case response if isLoginRedirect(response) => doPreviewAuth(request)
-      // Add the cookie to disable the consent management platform for GET requests
-      case response => Future.successful(ProxyResultWithBody(response, List(getDisableCmpCookie(request.requestHost))))
     }
+
   }
 
   private def doPreviewProxyPost(request: PreviewProxyRequest) = {

--- a/app/com/gu/viewer/proxy/ProxyResult.scala
+++ b/app/com/gu/viewer/proxy/ProxyResult.scala
@@ -2,18 +2,17 @@ package com.gu.viewer.proxy
 
 import com.gu.viewer.logging.Loggable
 import com.gu.viewer.views.html
-import play.api.http.CookiesConfiguration
 import play.api.http.HeaderNames._
 import play.api.http.MimeTypes._
 import play.api.mvc.Results._
-import play.api.mvc.{Cookie, CookieHeaderEncoding, Cookies, Result}
+import play.api.mvc.Result
 
 import scala.concurrent.{ExecutionContext, Future}
 
 
 sealed trait ProxyResult
 
-case class ProxyResultWithBody(response: ProxyResponse, CookiesToSet: List[Cookie] = List.empty) extends ProxyResult
+case class ProxyResultWithBody(response: ProxyResponse) extends ProxyResult
 
 case class RedirectProxyResult(location: String) extends ProxyResult
 
@@ -22,18 +21,17 @@ case class RedirectProxyResultWithSession(location: String, session: PreviewSess
 case class PreviewAuthRedirectProxyResult(location: String, session: PreviewSession) extends ProxyResult
 
 
-object ProxyResult extends Loggable with CookieHeaderEncoding {
-  protected def config: CookiesConfiguration = CookiesConfiguration(strict = true)
+object ProxyResult extends Loggable {
 
   /**
    * Convert ProxyResult to a Play Result
    */
-  private def asResult(proxyResult: ProxyResult): Result = proxyResult match {
+  def asResult(proxyResult: ProxyResult): Result = proxyResult match {
+
     // Stream body result
-    case ProxyResultWithBody(response, cookiesToSet) => {
+    case ProxyResultWithBody(response) => {
       val resultHeaders = Seq(
-        response.header(CONTENT_LENGTH).map(CONTENT_LENGTH -> _),
-        Some(SET_COOKIE -> encodeSetCookieHeader(cookiesToSet))
+        response.header(CONTENT_LENGTH).map(CONTENT_LENGTH -> _)
       ).flatten
 
       Status(response.status)


### PR DESCRIPTION
Reverts guardian/editorial-viewer#147.

This is causing problems previewing video, which [relies on consent being implicitly set.](https://github.com/guardian/dotcom-rendering/blob/5bbfd70e0e22f6c29f928b14f1f24dc43cf41b51/dotcom-rendering/src/components/YoutubeAtom/YoutubeAtom.tsx#L214) When the value on L214 in that file is `undefined`, the YoutubeAtomPlayer path is never rendered, and we don't get video.

The correct solution to this will explicitly set consent programmatically via a CMP API. It might be that another cookie to explicitly grant consent is necessary.