### PR TITLE
Add user benefit cookies

### DIFF
--- a/app/com/gu/viewer/proxy/LiveProxy.scala
+++ b/app/com/gu/viewer/proxy/LiveProxy.scala
@@ -2,18 +2,55 @@ package com.gu.viewer.proxy
 
 import com.gu.viewer.config.AppConfig
 import com.gu.viewer.logging.Loggable
+import play.api.mvc.Cookie
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
+import java.time.{LocalDateTime, ZoneOffset}
 
-class LiveProxy(proxyClient: ProxyClient, config: AppConfig)(implicit ec: ExecutionContext) extends Loggable {
+class LiveProxy(proxyClient: ProxyClient, config: AppConfig)(implicit
+    ec: ExecutionContext
+) extends Loggable {
 
   val serviceHost = config.liveHost
 
+  private def setCookieListForNonAdvertisingBanner(
+      domain: String
+  ): List[Cookie] = {
+
+    val expiryTime = LocalDateTime
+      .now(ZoneOffset.UTC)
+      .plusDays(7)
+      .toEpochSecond(ZoneOffset.UTC)
+      .toString
+
+    val cookieNames = List(
+      "gu_allow_reject_all",
+      "gu_hide_support_messaging",
+      "gu_user_benefits_expiry"
+    )
+
+    cookieNames.map(name =>
+      Cookie(
+        name = name,
+        value = expiryTime,
+        domain = Some(domain),
+        httpOnly = false
+      )
+    )
+  }
+
   def proxy(request: LiveProxyRequest) = ProxyResult.resultFrom {
     val url = s"https://$serviceHost/${request.servicePath}"
-    log.info(s"Live Proxy to: $url")
 
-    proxyClient.get(url)()
+    proxyClient.get(url, cookies = setCookieListForNonAdvertisingBanner(url)) {
+      case response =>
+        Future.successful(
+          ProxyResultWithBody(
+            response = response,
+            setCookieListForNonAdvertisingBanner(request.request.host)
+          )
+        )
+    }
   }
 
   def proxyPost(request: LiveProxyRequest) = ProxyResult.resultFrom {
@@ -21,5 +58,4 @@ class LiveProxy(proxyClient: ProxyClient, config: AppConfig)(implicit ec: Execut
     log.info(s"Live POST Proxy to: $url")
     proxyClient.post(destination = url, body = request.body.getOrElse(Map.empty))()
   }
-
 }

--- a/app/com/gu/viewer/proxy/ProxyRequest.scala
+++ b/app/com/gu/viewer/proxy/ProxyRequest.scala
@@ -10,14 +10,14 @@ object ProxyRequest {
     val queryString = if (request.rawQueryString.nonEmpty) s"?${request.rawQueryString}" else ""
 
     service match {
-      case "live" => LiveProxyRequest(servicePath + queryString, body)
+      case "live" => LiveProxyRequest(servicePath + queryString, request, body)
       case "preview" => PreviewProxyRequest(servicePath + queryString, request, body)
       case _ => UnknownProxyRequest
     }
   }
 }
 
-case class LiveProxyRequest(servicePath: String, body: Option[Map[String, Seq[String]]] = None) extends ProxyRequest
+case class LiveProxyRequest(servicePath: String, request: RequestHeader, body: Option[Map[String, Seq[String]]] = None) extends ProxyRequest
 
 case class PreviewProxyRequest(
   servicePath: String,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Add the  `gu_allow_reject_all`,  `gu_hide_support_messaging`, `gu_user_benefits_expiry` cookie to show the non-advertising banner from appearing in preview and live. Editorial have to accept cookies before previewing a page which is inconvenient. This PR will allow editorial to reject the cookies before previewing.


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Running locally and in CODE, remove all cookies for `viewer.${stage}` and load the live and preview page. The non advertising banner will appear.

<img width="1512" alt="Screenshot 2025-06-18 at 10 12 07" src="https://github.com/user-attachments/assets/1a867417-14f6-42dd-8c1a-eafcc42986eb" />

