### PR TITLE
Bump Scala to 2.13.18, Play to 3.0.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ lazy val root = (project in file("."))
      )
   )
 
-scalaVersion := "2.13.9"
+scalaVersion := "2.13.18"
 
 val awsVersion = "1.12.129"
 
@@ -48,4 +48,3 @@ packageSummary := "viewer"
 packageDescription := """wrapper over the preview mode to give different platform previews"""
 
 PlayKeys.devSettings += "play.server.pekko.max-header-size" -> "16k"
-

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 libraryDependencies += "org.vafer" % "jdeb" % "1.7" artifacts Artifact("jdeb", "jar", "jar")
 // The Play plugin
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.0")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.10")
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.3")
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
 


### PR DESCRIPTION
## What does this change?

Bump Scala to 2.9.18, Play to 3.0.10, to fix https://github.com/advisories/GHSA-cmp6-m4wj-q63q.

## How to test

Deploy to CODE. The application should run as expected.

- [x] Tested in CODE